### PR TITLE
[FEATURE]: Support Copy activities from SFTP

### DIFF
--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -144,14 +144,11 @@ def get_database_options(
     service_name = dataset_definition["service_name"]
     jdbc_url = get_jdbc_url(dataset_definition)
     url_line = f'{dataset_name}_options["url"] = "{jdbc_url}"'
-    secrets_lines = [
-        f"""{dataset_name}_options["{secret}"] = dbutils.secrets.get(
+    secrets_lines = [f"""{dataset_name}_options["{secret}"] = dbutils.secrets.get(
                 scope="{credentials_scope}",
                 key="{service_name}_{secret}"
             )
-            """
-        for secret in DATASET_PROVIDER_SECRETS[database_type]
-    ]
+            """ for secret in DATASET_PROVIDER_SECRETS[database_type]]
     options_lines = [
         f"""{dataset_name}_options["{option}"] = '{dataset_definition.get(option)}'"""
         for option in DATASET_OPTIONS.get(database_type, [])

--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -61,6 +61,9 @@ def get_option_expressions(dataset_definition: dict, credentials_scope: str = DE
         List of Python source lines that creates an options dictionary.
     """
     dataset_type = dataset_definition.get("type")
+    provider_type = dataset_definition.get("provider_type")
+    if provider_type == "sftp":
+        return get_sftp_options(dataset_definition, dataset_type or "csv", credentials_scope=credentials_scope)
     if dataset_type in {"avro", "csv", "json", "orc", "parquet"}:
         return get_file_options(dataset_definition, dataset_type, credentials_scope=credentials_scope)
     if dataset_type in {"sqlserver", "postgresql", "mysql", "oracle"}:
@@ -94,6 +97,37 @@ def get_file_options(
         records_per_file = dataset_definition.get("records_per_file")
         config_lines.append(f'spark.conf.set("spark.sql.files.maxRecordsPerFile", "{records_per_file}")')
     config_lines.extend(_get_file_credential_lines(dataset_definition, service_name, provider_type, credentials_scope))
+    return [f"{dataset_name}_options = {{}}", *config_lines]
+
+
+def get_sftp_options(
+    dataset_definition: dict, file_type: str, credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE
+) -> list[str]:
+    """
+    Generates code to create a Spark data source options dictionary for an SFTP file dataset.
+
+    SFTP datasets use a Unity Catalog connection and Auto Loader to read files.
+    Format-specific options (such as CSV delimiters) are included alongside the
+    SFTP connection path.
+
+    Args:
+        dataset_definition: Dataset definition dictionary.
+        file_type: File type (for example ``"csv"`` or ``"parquet"``).
+        credentials_scope: Name of the Databricks secret scope used for storing credentials.
+
+    Returns:
+        List of Python source lines that create the options dictionary.
+    """
+    dataset_name = dataset_definition["dataset_name"]
+    service_name = dataset_definition.get("service_name", "")
+    config_lines = [
+        rf'{dataset_name}_options["{option}"] = r"{dataset_definition.get(option)}"'
+        for option in DATASET_OPTIONS.get(file_type, [])
+        if dataset_definition.get(option)
+    ]
+    config_lines.append(
+        f'{dataset_name}_options["connection_name"] = "{service_name}_sftp_connection"'
+    )
     return [f"{dataset_name}_options = {{}}", *config_lines]
 
 
@@ -178,7 +212,10 @@ def get_read_expression(source_definition: dict, source_query: str | None = None
         ValueError: If the dataset type is not supported for reading.
     """
     source_type = source_definition.get("type")
+    provider_type = source_definition.get("provider_type")
 
+    if provider_type == "sftp":
+        return get_sftp_read_expression(source_definition)
     if source_type in {"avro", "csv", "json", "orc", "parquet"}:
         return get_file_read_expression(source_definition)
     if source_type == "delta":
@@ -215,6 +252,51 @@ def get_file_uri(definition: dict) -> str:
     # Default: ABFS (ADLS Gen2)
     storage_account_name = definition.get("storage_account_name", "")
     return f"abfss://{container}@{storage_account_name}.dfs.core.windows.net/{folder_path}"
+
+
+def get_sftp_file_uri(definition: dict) -> str:
+    """
+    Builds the volume path for an SFTP dataset definition.
+
+    Files ingested from SFTP via a Unity Catalog connection are accessed through
+    Databricks Volumes.  The path follows the pattern
+    ``/Volumes/<catalog>/<schema>/<volume>/<folder_path>``.
+
+    Args:
+        definition: Dataset definition dictionary containing service_name and folder_path.
+
+    Returns:
+        Volume path string for the SFTP dataset.
+    """
+    service_name = definition.get("service_name", "")
+    folder_path = definition.get("folder_path", "")
+    return f"/Volumes/wkmigrate/sftp/{service_name}/{folder_path}"
+
+
+def get_sftp_read_expression(source_definition: dict) -> str:
+    """
+    Generates code to read data from an SFTP dataset into a DataFrame using Auto Loader.
+
+    Auto Loader (``cloudFiles``) streams files from the SFTP volume path and
+    supports all common file formats.
+
+    Args:
+        source_definition: Dataset definition dictionary.
+
+    Returns:
+        Python source lines that read data into a DataFrame via Auto Loader.
+    """
+    source_name = source_definition["dataset_name"]
+    source_type = source_definition.get("type", "csv")
+    volume_path = get_sftp_file_uri(source_definition)
+
+    return f"""{source_name}_df = (
+                        spark.readStream.format("cloudFiles")
+                            .option("cloudFiles.format", "{source_type}")
+                            .options(**{source_name}_options)
+                            .load("{volume_path}")
+                        )
+                    """
 
 
 def get_file_read_expression(source_definition: dict) -> str:

--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -63,7 +63,7 @@ def get_option_expressions(dataset_definition: dict, credentials_scope: str = DE
     dataset_type = dataset_definition.get("type")
     provider_type = dataset_definition.get("provider_type")
     if provider_type == "sftp":
-        return get_sftp_options(dataset_definition, dataset_type or "csv", credentials_scope=credentials_scope)
+        return get_sftp_options(dataset_definition, dataset_type or "csv")
     if dataset_type in {"avro", "csv", "json", "orc", "parquet"}:
         return get_file_options(dataset_definition, dataset_type, credentials_scope=credentials_scope)
     if dataset_type in {"sqlserver", "postgresql", "mysql", "oracle"}:
@@ -100,9 +100,7 @@ def get_file_options(
     return [f"{dataset_name}_options = {{}}", *config_lines]
 
 
-def get_sftp_options(
-    dataset_definition: dict, file_type: str, credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE
-) -> list[str]:
+def get_sftp_options(dataset_definition: dict, file_type: str) -> list[str]:
     """
     Generates code to create a Spark data source options dictionary for an SFTP file dataset.
 
@@ -113,7 +111,6 @@ def get_sftp_options(
     Args:
         dataset_definition: Dataset definition dictionary.
         file_type: File type (for example ``"csv"`` or ``"parquet"``).
-        credentials_scope: Name of the Databricks secret scope used for storing credentials.
 
     Returns:
         List of Python source lines that create the options dictionary.
@@ -125,7 +122,7 @@ def get_sftp_options(
         for option in DATASET_OPTIONS.get(file_type, [])
         if dataset_definition.get(option)
     ]
-    config_lines.append(f'{dataset_name}_options["connection_name"] = "{service_name}_sftp_connection"')
+    config_lines.append(f'{dataset_name}_options["cloudFiles.connectionName"] = "{service_name}_sftp_connection"')
     return [f"{dataset_name}_options = {{}}", *config_lines]
 
 
@@ -252,7 +249,7 @@ def get_file_uri(definition: dict) -> str:
     return f"abfss://{container}@{storage_account_name}.dfs.core.windows.net/{folder_path}"
 
 
-def get_sftp_file_uri(definition: dict) -> str:
+def get_sftp_file_uri(definition: dict, catalog: str = "wkmigrate", schema: str = "sftp") -> str:
     """
     Builds the volume path for an SFTP dataset definition.
 
@@ -262,13 +259,15 @@ def get_sftp_file_uri(definition: dict) -> str:
 
     Args:
         definition: Dataset definition dictionary containing service_name and folder_path.
+        catalog: Unity Catalog catalog name (default ``"wkmigrate"``).
+        schema: Unity Catalog schema name (default ``"sftp"``).
 
     Returns:
         Volume path string for the SFTP dataset.
     """
     service_name = definition.get("service_name", "")
     folder_path = definition.get("folder_path", "")
-    return f"/Volumes/wkmigrate/sftp/{service_name}/{folder_path}"
+    return f"/Volumes/{catalog}/{schema}/{service_name}/{folder_path}"
 
 
 def get_sftp_read_expression(source_definition: dict) -> str:
@@ -289,7 +288,7 @@ def get_sftp_read_expression(source_definition: dict) -> str:
     volume_path = get_sftp_file_uri(source_definition)
 
     return f"""{source_name}_df = (
-                        spark.readStream.format("cloudFiles")
+                        spark.read.format("cloudFiles")
                             .option("cloudFiles.format", "{source_type}")
                             .options(**{source_name}_options)
                             .load("{volume_path}")

--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -314,6 +314,7 @@ def get_sftp_write_expression(dataset_name: str, sink_table: str, checkpoint_pat
     """
     return (
         f"{dataset_name}_df.writeStream \\\n"
+        f'    .outputMode("append") \\\n'
         f"    .trigger(availableNow=True) \\\n"
         f'    .option("checkpointLocation", "{checkpoint_path}") \\\n'
         f'    .toTable("{sink_table}")\n'

--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -144,11 +144,14 @@ def get_database_options(
     service_name = dataset_definition["service_name"]
     jdbc_url = get_jdbc_url(dataset_definition)
     url_line = f'{dataset_name}_options["url"] = "{jdbc_url}"'
-    secrets_lines = [f"""{dataset_name}_options["{secret}"] = dbutils.secrets.get(
+    secrets_lines = [
+        f"""{dataset_name}_options["{secret}"] = dbutils.secrets.get(
                 scope="{credentials_scope}",
                 key="{service_name}_{secret}"
             )
-            """ for secret in DATASET_PROVIDER_SECRETS[database_type]]
+            """
+        for secret in DATASET_PROVIDER_SECRETS[database_type]
+    ]
     options_lines = [
         f"""{dataset_name}_options["{option}"] = '{dataset_definition.get(option)}'"""
         for option in DATASET_OPTIONS.get(database_type, [])
@@ -246,25 +249,29 @@ def get_file_uri(definition: dict) -> str:
     return f"abfss://{container}@{storage_account_name}.dfs.core.windows.net/{folder_path}"
 
 
-def get_sftp_file_uri(definition: dict, catalog: str = "wkmigrate", schema: str = "sftp") -> str:
+def sftp_file_uri(definition: dict) -> str:
     """
-    Builds the volume path for an SFTP dataset definition.
+    Builds the direct SFTP URI for an SFTP dataset definition.
 
-    Files ingested from SFTP via a Unity Catalog connection are accessed through
-    Databricks Volumes.  The path follows the pattern
-    ``/Volumes/<catalog>/<schema>/<volume>/<folder_path>``.
+    The URI uses the ``sftp://`` scheme and references the host, port, and
+    folder path directly.  Unity Catalog volumes cannot be created from an
+    SFTP connection, so the URI must point to the SFTP server directly.
 
     Args:
-        definition: Dataset definition dictionary containing service_name and folder_path.
-        catalog: Unity Catalog catalog name (default ``"wkmigrate"``).
-        schema: Unity Catalog schema name (default ``"sftp"``).
+        definition: Dataset definition dictionary containing url (or host/port)
+            and folder_path.
 
     Returns:
-        Volume path string for the SFTP dataset.
+        SFTP URI string (e.g. ``sftp://host:port/path``).
     """
-    service_name = definition.get("service_name", "")
+    from urllib.parse import urlparse
+
+    url = definition.get("url", "")
+    parsed = urlparse(url)
+    host = parsed.hostname or definition.get("host", "<SFTP_HOST>")
+    port = parsed.port or definition.get("port", 22)
     folder_path = definition.get("folder_path", "")
-    return f"/Volumes/{catalog}/{schema}/{service_name}/{folder_path}"
+    return f"sftp://{host}:{port}/{folder_path}"
 
 
 def get_sftp_read_expression(source_definition: dict) -> str:
@@ -282,18 +289,23 @@ def get_sftp_read_expression(source_definition: dict) -> str:
     """
     source_name = source_definition["dataset_name"]
     source_type = source_definition.get("type", "csv")
-    volume_path = get_sftp_file_uri(source_definition)
+    file_uri = sftp_file_uri(source_definition)
 
     return f"""{source_name}_df = (
                         spark.readStream.format("cloudFiles")
                             .option("cloudFiles.format", "{source_type}")
                             .options(**{source_name}_options)
-                            .load("{volume_path}")
+                            .load("{file_uri}")
                         )
                     """
 
 
-def get_sftp_write_expression(dataset_name: str, sink_table: str, checkpoint_path: str) -> str:
+def get_sftp_write_expression(
+    dataset_name: str,
+    sink_format: str,
+    sink_path: str,
+    checkpoint_path: str,
+) -> str:
     """
     Generates a streaming write expression for Auto Loader SFTP ingestion.
 
@@ -301,9 +313,14 @@ def get_sftp_write_expression(dataset_name: str, sink_table: str, checkpoint_pat
     ``trigger(availableNow=True)`` processes all available files and then
     stops, giving batch-like semantics on top of streaming infrastructure.
 
+    Writes use ``format`` / ``option("path", ...)`` / ``start()`` /
+    ``awaitTermination()`` rather than ``toTable`` because the sink may not
+    be a Delta table.
+
     Args:
         dataset_name: Name of the DataFrame variable (without ``_df`` suffix).
-        sink_table: Fully-qualified target table name.
+        sink_format: Spark write format (e.g. ``"delta"``, ``"csv"``, ``"parquet"``).
+        sink_path: Output path for the written data.
         checkpoint_path: Path used by Structured Streaming for checkpointing.
 
     Returns:
@@ -311,10 +328,13 @@ def get_sftp_write_expression(dataset_name: str, sink_table: str, checkpoint_pat
     """
     return (
         f"{dataset_name}_df.writeStream \\\n"
+        f'    .format("{sink_format}") \\\n'
         f'    .outputMode("append") \\\n'
         f"    .trigger(availableNow=True) \\\n"
         f'    .option("checkpointLocation", "{checkpoint_path}") \\\n'
-        f'    .toTable("{sink_table}")\n'
+        f'    .option("path", "{sink_path}") \\\n'
+        f"    .start() \\\n"
+        f"    .awaitTermination()\n"
     )
 
 

--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -288,12 +288,36 @@ def get_sftp_read_expression(source_definition: dict) -> str:
     volume_path = get_sftp_file_uri(source_definition)
 
     return f"""{source_name}_df = (
-                        spark.read.format("cloudFiles")
+                        spark.readStream.format("cloudFiles")
                             .option("cloudFiles.format", "{source_type}")
                             .options(**{source_name}_options)
                             .load("{volume_path}")
                         )
                     """
+
+
+def get_sftp_write_expression(dataset_name: str, sink_table: str, checkpoint_path: str) -> str:
+    """
+    Generates a streaming write expression for Auto Loader SFTP ingestion.
+
+    Auto Loader requires ``readStream`` / ``writeStream``.  Using
+    ``trigger(availableNow=True)`` processes all available files and then
+    stops, giving batch-like semantics on top of streaming infrastructure.
+
+    Args:
+        dataset_name: Name of the DataFrame variable (without ``_df`` suffix).
+        sink_table: Fully-qualified target table name.
+        checkpoint_path: Path used by Structured Streaming for checkpointing.
+
+    Returns:
+        Python source fragment with the streaming write expression.
+    """
+    return (
+        f"{dataset_name}_df.writeStream \\\n"
+        f"    .trigger(availableNow=True) \\\n"
+        f'    .option("checkpointLocation", "{checkpoint_path}") \\\n'
+        f'    .toTable("{sink_table}")\n'
+    )
 
 
 def get_file_read_expression(source_definition: dict) -> str:
@@ -518,7 +542,7 @@ def _get_file_credential_lines(
     # Default: ABFS (ADLS Gen2)
     return [
         f"""spark.conf.set(
-                "fs.azure.account.key.{dataset_definition.get('storage_account_name')}.dfs.core.windows.net",
+                "fs.azure.account.key.{dataset_definition.get("storage_account_name")}.dfs.core.windows.net",
                     dbutils.secrets.get(
                         scope="{credentials_scope}",
                         key="{service_name}_storage_account_key"

--- a/src/wkmigrate/code_generator.py
+++ b/src/wkmigrate/code_generator.py
@@ -125,9 +125,7 @@ def get_sftp_options(
         for option in DATASET_OPTIONS.get(file_type, [])
         if dataset_definition.get(option)
     ]
-    config_lines.append(
-        f'{dataset_name}_options["connection_name"] = "{service_name}_sftp_connection"'
-    )
+    config_lines.append(f'{dataset_name}_options["connection_name"] = "{service_name}_sftp_connection"')
     return [f"{dataset_name}_options = {{}}", *config_lines]
 
 

--- a/src/wkmigrate/definition_stores/workspace_definition_store.py
+++ b/src/wkmigrate/definition_stores/workspace_definition_store.py
@@ -90,6 +90,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
             "schema",
             "workspace_url",
             "credentials_scope",
+            "default_catalog_name",
         }
     )
     _valid_compute_types = frozenset({"serverless", "classic"})
@@ -188,6 +189,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
         self._upload_notebooks(client, prepared.all_notebooks)
         self._materialize_secrets(client, prepared.all_secrets)
         self._materialize_pipelines(client, prepared.all_pipelines)
+        self._materialize_setup_tasks(client, prepared)
         self._ensure_notebook_dependencies(client, prepared.tasks)
         inner_job_ids = self._create_inner_jobs(client, prepared.inner_workflows)
         if inner_job_ids:
@@ -324,6 +326,10 @@ class WorkspaceDefinitionStore(DefinitionStore):
         """Returns the credentials_scope option, or the default scope if not set."""
         return self.options.get('credentials_scope', DEFAULT_CREDENTIALS_SCOPE)
 
+    def _effective_default_catalog_name(self) -> str:
+        """Returns the default_catalog_name option, or ``'wkmigrate'`` if not set."""
+        return self.options.get('default_catalog_name', 'wkmigrate')
+
     def _validate_option_keys(self, keys: Iterable[str]) -> None:
         """
         Validates that all provided keys are recognised option keys.
@@ -370,6 +376,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
             pipeline=pipeline_definition,
             files_to_delta_sinks=self._effective_files_to_delta_sinks(),
             credentials_scope=self._effective_credentials_scope(),
+            default_catalog_name=self._effective_default_catalog_name(),
         )
         return self._apply_options(prepared, defer_root_path=defer_root_path)
 
@@ -702,6 +709,33 @@ class WorkspaceDefinitionStore(DefinitionStore):
             value = secret.provided_value or "PLACEHOLDER_SECRET_VALUE"
             client.secrets.put_secret(scope=secret.scope, key=secret.key, string_value=value)
 
+    @staticmethod
+    def _materialize_setup_tasks(
+        client: WorkspaceClient,
+        prepared: PreparedWorkflow,
+    ) -> None:
+        """
+        Creates one-time setup jobs for activities that require them.
+
+        Each setup task is created as a separate single-task job so operators
+        can run them once before the main workflow.
+
+        Args:
+            client: Authenticated workspace client.
+            prepared: Prepared workflow containing activities with setup tasks.
+        """
+        setup_tasks = prepared.all_setup_tasks
+        if not setup_tasks:
+            return
+        for setup_task in setup_tasks:
+            job_name = setup_task.get("task_key", "setup_task")
+            response = client.jobs.create(
+                name=f"{job_name}_setup",
+                tasks=[Task.from_dict(setup_task)],
+            )
+            if response.job_id:
+                logger.info("Created setup job '%s_setup' (id=%s)", job_name, response.job_id)
+
     def _ensure_notebook_dependencies(
         self,
         client: WorkspaceClient,
@@ -841,6 +875,17 @@ class WorkspaceDefinitionStore(DefinitionStore):
             inner_resource = {"resources": {"jobs": {inner_name: self._serialize_for_json(inner_settings)}}}
             with open(inner_job_file, "w", encoding="utf-8") as inner_handle:
                 yaml.safe_dump(inner_resource, inner_handle, sort_keys=False)
+
+        for idx, setup_task in enumerate(prepared.all_setup_tasks):
+            setup_name = setup_task.get("task_key", f"setup_task_{idx}")
+            setup_job_file = os.path.join(jobs_dir, f"{setup_name}_setup.yml")
+            setup_settings = {
+                "name": f"{setup_name}_setup",
+                "tasks": [setup_task],
+            }
+            setup_resource = {"resources": {"jobs": {f"{setup_name}_setup": self._serialize_for_json(setup_settings)}}}
+            with open(setup_job_file, "w", encoding="utf-8") as setup_handle:
+                yaml.safe_dump(setup_resource, setup_handle, sort_keys=False)
 
         self._write_notebooks(prepared.all_notebooks, notebooks_dir)
         self._write_pipeline_resources(prepared.all_pipelines, pipelines_dir)

--- a/src/wkmigrate/models/ir/linked_services.py
+++ b/src/wkmigrate/models/ir/linked_services.py
@@ -105,6 +105,24 @@ class AzureBlobLinkedService(LinkedService):
 
 
 @dataclass(slots=True)
+class SftpLinkedService(LinkedService):
+    """
+    Linked-service metadata for an SFTP server.
+
+    Attributes:
+        host: Hostname or IP address of the SFTP server.
+        port: TCP port number for the SFTP connection.
+        user_name: Username used to authenticate with the SFTP server.
+        authentication_type: Authentication mechanism (for example ``Basic`` or ``SshPublicKey``).
+    """
+
+    host: str
+    port: int = 22
+    user_name: str | None = None
+    authentication_type: str | None = None
+
+
+@dataclass(slots=True)
 class DatabricksClusterLinkedService(LinkedService):
     """
     Linked-service metadata describing a Databricks workspace/cluster.

--- a/src/wkmigrate/models/workflows/artifacts.py
+++ b/src/wkmigrate/models/workflows/artifacts.py
@@ -59,6 +59,17 @@ class PreparedWorkflow:
         return result
 
     @property
+    def all_setup_tasks(self) -> list[dict[str, Any]]:
+        """All setup tasks across this workflow and any nested inner workflows."""
+        result: list[dict[str, Any]] = []
+        for activity in self.activities:
+            if activity.setup_task:
+                result.append(activity.setup_task)
+            if activity.inner_workflow:
+                result.extend(activity.inner_workflow.all_setup_tasks)
+        return result
+
+    @property
     def inner_workflows(self) -> list["PreparedWorkflow"]:
         """All inner workflows (recursively) produced by activities in this workflow."""
         result: list[PreparedWorkflow] = []
@@ -80,6 +91,7 @@ class PreparedActivity:
         pipelines: List of ``PipelineInstruction`` objects describing DLT pipelines to create.
         secrets: List of ``SecretInstruction`` objects describing secrets to materialize.
         inner_workflow: Additional workflow settings created for nested ForEach tasks.
+        setup_task: Optional one-time setup task configuration (e.g. UC connection creation).
     """
 
     task: dict[str, Any]
@@ -87,6 +99,7 @@ class PreparedActivity:
     pipelines: list[PipelineInstruction] | None = None
     secrets: list[SecretInstruction] | None = None
     inner_workflow: "PreparedWorkflow" | None = None
+    setup_task: dict[str, Any] | None = None
 
 
 @dataclass(slots=True)

--- a/src/wkmigrate/parsers/dataset_parsers.py
+++ b/src/wkmigrate/parsers/dataset_parsers.py
@@ -35,6 +35,7 @@ CLOUD_LOCATION_TYPES: dict[str, str] = {
     "GoogleCloudStorageLocation": "gcs",
     "AzureBlobStorageLocation": "azure_blob",
     "AzureBlobFSLocation": "abfs",
+    "SftpLocation": "sftp",
 }
 DEFAULT_CREDENTIALS_SCOPE = "wkmigrate_credentials_scope"
 DATASET_PROVIDER_SECRETS: dict[str, list[str]] = {
@@ -46,6 +47,7 @@ DATASET_PROVIDER_SECRETS: dict[str, list[str]] = {
     "oracle": _JDBC_SECRETS,
     "postgresql": _JDBC_SECRETS,
     "s3": ["access_key_id", "secret_access_key"],
+    "sftp": ["user_name", "password"],
     "sqlserver": _JDBC_SECRETS,
 }
 DATASET_OPTIONS: dict[str, list[str]] = {

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -9,6 +9,7 @@ definition, notebook artifacts, and secrets to be created in the target workspac
 from __future__ import annotations
 
 from dataclasses import asdict
+from urllib.parse import urlparse
 
 import autopep8  # type: ignore
 
@@ -61,7 +62,13 @@ def prepare_copy_activity(
 
     if source_provider_type == "sftp":
         return _prepare_sftp_copy(
-            activity, source_definition, sink_definition, column_mapping, secrets_to_collect, credentials_scope
+            activity,
+            source_definition,
+            sink_definition,
+            column_mapping,
+            secrets_to_collect,
+            credentials_scope,
+            default_files_to_delta_sinks,
         )
 
     files_to_delta_sinks = sink_definition.get("type") == "delta"
@@ -121,11 +128,12 @@ def _prepare_sftp_copy(
     column_mapping: list[dict],
     secrets_to_collect: list,
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+    default_files_to_delta_sinks: bool | None = None,
 ) -> PreparedActivity:
     """
     Builds tasks and artifacts for a Copy activity that reads from an SFTP source.
 
-    SFTP sources use Auto Loader to stream files from a Unity Catalog volume
+    SFTP sources use Auto Loader to read files from a Unity Catalog volume
     backed by an SFTP connection.  In addition to the main copy notebook, a
     one-time setup notebook is generated to create the UC connection and
     external volume.
@@ -137,15 +145,20 @@ def _prepare_sftp_copy(
         column_mapping: Column-level mappings from source to sink.
         secrets_to_collect: Secret instructions for the source and sink.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
+        default_files_to_delta_sinks: Optional override for DLT generation.
 
     Returns:
         PreparedActivity with notebook tasks and setup notebook artifacts.
     """
+    files_to_delta_sinks = sink_definition.get("type") == "delta"
+    if default_files_to_delta_sinks is not None:
+        files_to_delta_sinks = default_files_to_delta_sinks
+
     notebook_path, notebook = _create_copy_data_notebook(
         source_definition,
         sink_definition,
         column_mapping,
-        files_to_delta_sinks=False,
+        files_to_delta_sinks=files_to_delta_sinks,
         credentials_scope=credentials_scope,
     )
 
@@ -187,8 +200,12 @@ def _build_sftp_setup_notebook(
     """
     source_name = source_definition.get("dataset_name", "source")
     service_name = source_definition.get("service_name", source_name)
-    host = source_definition.get("host", "<SFTP_HOST>")
-    port = source_definition.get("port", 22)
+
+    # Parse host/port from the url field (e.g. "sftp://host:port")
+    url = source_definition.get("url", "")
+    parsed = urlparse(url)
+    host = parsed.hostname or source_definition.get("host", "<SFTP_HOST>")
+    port = parsed.port or source_definition.get("port", 22)
     connection_name = f"{service_name}_sftp_connection"
     volume_path = get_sftp_file_uri(source_definition)
     notebook_path = f"/wkmigrate/sftp_setup/{connection_name}_setup"

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -158,9 +158,17 @@ def _prepare_sftp_copy(
     Returns:
         PreparedActivity with notebook tasks and setup notebook artifacts.
     """
-    files_to_delta_sinks = sink_definition.get("type") == "delta"
-    if default_files_to_delta_sinks is not None:
+    sink_is_delta = sink_definition.get("type") == "delta"
+
+    # Delta sinks must always use the DLT pipeline path because the streaming
+    # notebook writes via `.option("path", ...)` which requires a filesystem
+    # path -- a three-part table name is invalid there.
+    if sink_is_delta:
+        files_to_delta_sinks = True
+    elif default_files_to_delta_sinks is not None:
         files_to_delta_sinks = default_files_to_delta_sinks
+    else:
+        files_to_delta_sinks = False
 
     setup_notebook = _build_sftp_setup_notebook(
         source_definition,
@@ -351,6 +359,7 @@ def _build_sftp_setup_notebook(
                 f'password = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_password")',
                 "",
                 "# Escape single quotes in credentials to prevent SQL injection",
+                "host = host.replace(\"'\", \"''\")",
                 "user_name = user_name.replace(\"'\", \"''\")",
                 "password = password.replace(\"'\", \"''\")",
                 "",
@@ -379,6 +388,9 @@ def _build_sftp_setup_notebook(
                 f'user_name = "<{auth_type}_USER>"',
                 f'password = "<{auth_type}_PASSWORD>"',
                 f'key_fingerprint = "<{auth_type}_KEY_FINGERPRINT>"',
+                "",
+                "# Escape single quotes to prevent SQL injection",
+                "host = host.replace(\"'\", \"''\")",
                 "",
                 'spark.sql(f"""',
                 "    CREATE CONNECTION IF NOT EXISTS `{connection_name}`",

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -267,18 +267,17 @@ def _create_sftp_streaming_notebook(
     source_name = source_definition.get("dataset_name", "source")
     sink_name = sink_definition.get("dataset_name", "sink")
     sink_type = sink_definition.get("type", "delta")
-    database_name = sink_definition.get("database_name", "default")
-    table_name = sink_definition.get("table_name", sink_name)
     checkpoint_path = f"/Volumes/{default_catalog_name}/sftp/_checkpoints/{activity_key}"
 
     if sink_type == "delta":
-        sink_path = f"{default_catalog_name}.{database_name}.{table_name}"
-        sink_format = "delta"
-    else:
-        sink_container = sink_definition.get("container", "")
-        sink_folder = sink_definition.get("folder_path", "")
-        sink_path = f"/Volumes/{default_catalog_name}/sftp/{sink_container}/{sink_folder}"
-        sink_format = sink_type
+        raise ValueError(
+            "Delta sinks must use the DLT pipeline path, not the streaming notebook"
+        )
+
+    sink_container = sink_definition.get("container", "")
+    sink_folder = sink_definition.get("folder_path", "")
+    sink_path = f"/Volumes/{default_catalog_name}/sftp/{sink_container}/{sink_folder}"
+    sink_format = sink_type
 
     script_lines = [
         "# Databricks notebook source",
@@ -413,7 +412,7 @@ def _build_sftp_setup_notebook(
             "",
             f"# Step 2: Verify SFTP connection",
             f'spark.sql("""',
-            f"    CREATE SCHEMA IF NOT EXISTS {default_catalog_name}.sftp",
+            f"    CREATE SCHEMA IF NOT EXISTS `{default_catalog_name}`.sftp",
             '""")',
             "",
             f'print("SFTP connection \\"{connection_name}\\" configured.")',
@@ -433,7 +432,7 @@ def _build_sftp_setup_notebook(
                 "",
                 f"# Step 3: Create external volume for the sink bucket/container",
                 f'spark.sql("""',
-                f"    CREATE EXTERNAL VOLUME IF NOT EXISTS {default_catalog_name}.sftp.`{sink_service_name}_{sink_container}`",
+                f"    CREATE EXTERNAL VOLUME IF NOT EXISTS `{default_catalog_name}`.sftp.`{sink_service_name}_{sink_container}`",
                 f"    LOCATION '{volume_location}'",
                 '""")',
                 "",

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -24,6 +24,7 @@ from wkmigrate.code_generator import (
     get_option_expressions,
     get_read_expression,
     get_sftp_file_uri,
+    get_sftp_write_expression,
 )
 from wkmigrate.models.ir.pipeline import CopyActivity
 from wkmigrate.models.workflows.artifacts import NotebookArtifact, PreparedActivity
@@ -154,20 +155,20 @@ def _prepare_sftp_copy(
     if default_files_to_delta_sinks is not None:
         files_to_delta_sinks = default_files_to_delta_sinks
 
-    notebook_path, notebook = _create_copy_data_notebook(
-        source_definition,
-        sink_definition,
-        column_mapping,
-        files_to_delta_sinks=files_to_delta_sinks,
-        credentials_scope=credentials_scope,
-    )
-
     setup_notebook = _build_sftp_setup_notebook(source_definition, credentials_scope)
-    notebooks = [setup_notebook, notebook]
-
     base_task = get_base_task(activity)
 
     if not files_to_delta_sinks:
+        # Auto Loader requires readStream/writeStream.  Use trigger(availableNow=True)
+        # for batch-like semantics: process all available files then stop.
+        notebook_path, notebook = _create_sftp_streaming_notebook(
+            activity.task_key,
+            source_definition,
+            sink_definition,
+            column_mapping,
+            credentials_scope=credentials_scope,
+        )
+        notebooks = [setup_notebook, notebook]
         task = parse_mapping(
             {
                 **base_task,
@@ -180,7 +181,15 @@ def _prepare_sftp_copy(
             secrets=secrets_to_collect if secrets_to_collect else None,
         )
 
-    # DLT pipeline execution
+    # DLT pipeline execution — DLT handles streaming natively
+    notebook_path, notebook = _create_copy_data_notebook(
+        source_definition,
+        sink_definition,
+        column_mapping,
+        files_to_delta_sinks=True,
+        credentials_scope=credentials_scope,
+    )
+    notebooks = [setup_notebook, notebook]
     pipeline_name = f"{activity.task_key}_pipeline"
     task = parse_mapping(
         {
@@ -200,6 +209,64 @@ def _prepare_sftp_copy(
             )
         ],
     )
+
+
+def _create_sftp_streaming_notebook(
+    activity_key: str,
+    source_definition: dict,
+    sink_definition: dict,
+    column_mapping: list[dict],
+    credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+) -> tuple[str, NotebookArtifact]:
+    """
+    Generates a notebook that reads from SFTP via Auto Loader and writes with Structured Streaming.
+
+    Auto Loader (``cloudFiles``) is a streaming source only, so this notebook
+    uses ``readStream`` / ``writeStream`` with ``trigger(availableNow=True)``
+    to process all available files in a single micro-batch and then stop.
+
+    Args:
+        activity_key: Task key used for checkpoint path naming.
+        source_definition: Merged source dataset definition dictionary.
+        sink_definition: Merged sink dataset definition dictionary.
+        column_mapping: Column-level mappings from source to sink.
+        credentials_scope: Name of the Databricks secret scope used for storing credentials.
+
+    Returns:
+        Tuple of ``(notebook_path, NotebookArtifact)``.
+    """
+    source_name = source_definition.get("dataset_name", "source")
+    sink_name = sink_definition.get("dataset_name", "sink")
+    sink_type = sink_definition.get("type", "delta")
+    database_name = sink_definition.get("database_name", "default")
+    table_name = sink_definition.get("table_name", sink_name)
+    checkpoint_path = f"/Volumes/wkmigrate/sftp/_checkpoints/{activity_key}"
+
+    # Determine sink table reference
+    if sink_type == "delta":
+        sink_table = f"hive_metastore.{database_name}.{table_name}"
+    else:
+        sink_table = f"wkmigrate.sftp.{sink_name}"
+
+    script_lines = [
+        "# Databricks notebook source",
+        "import pyspark.sql.types as T",
+        "import pyspark.sql.functions as F",
+        "",
+        "# Set the source options:",
+    ]
+    script_lines.extend(get_option_expressions(source_definition, credentials_scope))
+    script_lines.append("# Read from the SFTP source via Auto Loader (streaming):")
+    script_lines.append(get_read_expression(source_definition))
+    script_lines.append("# Map the source columns to the target columns:")
+    script_lines.append(_get_mapping(source_definition, sink_definition, column_mapping, True))
+    script_lines.append("# Write to the target using Structured Streaming with trigger(availableNow=True):")
+    script_lines.append(get_sftp_write_expression(sink_name, sink_table, checkpoint_path))
+
+    notebook_content = autopep8.fix_code("\n".join(script_lines))
+    notebook_path = f"/wkmigrate/copy_data_notebooks/copy_{source_name}_to_{sink_name}"
+    notebook_artifact = NotebookArtifact(file_path=notebook_path, content=notebook_content)
+    return notebook_path, notebook_artifact
 
 
 def _build_sftp_setup_notebook(
@@ -233,6 +300,12 @@ def _build_sftp_setup_notebook(
     volume_path = get_sftp_file_uri(source_definition)
     notebook_path = f"/wkmigrate/sftp_setup/{connection_name}_setup"
 
+    # NOTE: This notebook mixes two kinds of f-string interpolation:
+    # - Build-time (Python f-strings here): {host}, {port}, {connection_name},
+    #   {credentials_scope}, {service_name} are resolved when generating the notebook.
+    # - Runtime (f-strings in the emitted notebook code): {connection_name}, {host},
+    #   {port}, {user_name}, {password} inside spark.sql(f"...") are resolved when
+    #   the notebook executes in Databricks, referencing local Python variables.
     lines = [
         "# Databricks notebook source",
         "# SFTP Connection - One-Time Setup Notebook",
@@ -244,11 +317,11 @@ def _build_sftp_setup_notebook(
         "# Step 1: Create the Unity Catalog connection to the SFTP server",
         f'connection_name = "{connection_name}"',
         f'host = "{host}"',
-        f'port = {port}',
+        f"port = {port}",
         f'user_name = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_user_name")',
         f'password = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_password")',
         "",
-        "spark.sql(f\"\"\"",
+        'spark.sql(f"""',
         "    CREATE CONNECTION IF NOT EXISTS `{connection_name}`",
         "    TYPE sftp",
         "    OPTIONS (",
@@ -257,7 +330,7 @@ def _build_sftp_setup_notebook(
         "        username '{user_name}',",
         "        password '{password}'",
         "    )",
-        "\"\"\")",
+        '""")',
         "",
         "# COMMAND ----------",
         "",
@@ -266,11 +339,11 @@ def _build_sftp_setup_notebook(
         "    CREATE SCHEMA IF NOT EXISTS wkmigrate.sftp",
         '""")',
         "",
-        "spark.sql(f\"\"\"",
-        f'    CREATE EXTERNAL VOLUME IF NOT EXISTS wkmigrate.sftp.`{service_name}`',
+        'spark.sql(f"""',
+        f"    CREATE EXTERNAL VOLUME IF NOT EXISTS wkmigrate.sftp.`{service_name}`",
         "    LOCATION 'sftp://{host}:{port}/'",
         "    CONNECTION `{connection_name}`",
-        "\"\"\")",
+        '""")',
         "",
         f'print("SFTP connection \\"{connection_name}\\" and volume configured.")',
         f'print("Files will be available at: {volume_path}")',

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -23,9 +23,11 @@ from wkmigrate.code_generator import (
     get_file_uri,
     get_option_expressions,
     get_read_expression,
-    get_sftp_file_uri,
+    sftp_file_uri,
     get_sftp_write_expression,
 )
+import warnings
+
 from wkmigrate.models.ir.pipeline import CopyActivity
 from wkmigrate.models.workflows.artifacts import NotebookArtifact, PreparedActivity
 from wkmigrate.models.workflows.instructions import PipelineInstruction
@@ -37,6 +39,7 @@ def prepare_copy_activity(
     activity: CopyActivity,
     default_files_to_delta_sinks: bool | None,
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+    default_catalog_name: str = "wkmigrate",
 ) -> PreparedActivity:
     """
     Builds tasks and artifacts for a Copy activity.
@@ -45,6 +48,7 @@ def prepare_copy_activity(
         activity: Activity definition emitted by the translators.
         default_files_to_delta_sinks: Optional override for DLT generation.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
+        default_catalog_name: Default Unity Catalog catalog name for generated artifacts.
 
     Returns:
         PreparedActivity containing task configuration and artifacts.
@@ -70,6 +74,7 @@ def prepare_copy_activity(
             secrets_to_collect,
             credentials_scope,
             default_files_to_delta_sinks,
+            default_catalog_name,
         )
 
     files_to_delta_sinks = sink_definition.get("type") == "delta"
@@ -130,14 +135,15 @@ def _prepare_sftp_copy(
     secrets_to_collect: list,
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
     default_files_to_delta_sinks: bool | None = None,
+    default_catalog_name: str = "wkmigrate",
 ) -> PreparedActivity:
     """
     Builds tasks and artifacts for a Copy activity that reads from an SFTP source.
 
-    SFTP sources use Auto Loader to read files from a Unity Catalog volume
-    backed by an SFTP connection.  In addition to the main copy notebook, a
-    one-time setup notebook is generated to create the UC connection and
-    external volume.
+    SFTP sources use Auto Loader to read files directly from the SFTP server
+    via a Unity Catalog connection.  A one-time setup notebook is generated to
+    create the UC connection.  For non-Delta sinks, a UC external volume is
+    created for the sink bucket/container.
 
     Args:
         activity: Copy activity definition from the translator layer.
@@ -147,6 +153,7 @@ def _prepare_sftp_copy(
         secrets_to_collect: Secret instructions for the source and sink.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
         default_files_to_delta_sinks: Optional override for DLT generation.
+        default_catalog_name: Default Unity Catalog catalog name for generated artifacts.
 
     Returns:
         PreparedActivity with notebook tasks and setup notebook artifacts.
@@ -155,7 +162,19 @@ def _prepare_sftp_copy(
     if default_files_to_delta_sinks is not None:
         files_to_delta_sinks = default_files_to_delta_sinks
 
-    setup_notebook = _build_sftp_setup_notebook(source_definition, credentials_scope)
+    setup_notebook = _build_sftp_setup_notebook(
+        source_definition,
+        sink_definition,
+        credentials_scope,
+        default_catalog_name,
+        create_sink_volume=not files_to_delta_sinks,
+    )
+    setup_task = parse_mapping(
+        {
+            "task_key": f"{activity.task_key}_sftp_setup",
+            "notebook_task": {"notebook_path": setup_notebook.file_path},
+        }
+    )
     base_task = get_base_task(activity)
 
     if not files_to_delta_sinks:
@@ -165,6 +184,7 @@ def _prepare_sftp_copy(
             sink_definition,
             column_mapping,
             credentials_scope=credentials_scope,
+            default_catalog_name=default_catalog_name,
         )
         notebooks = [setup_notebook, notebook]
         task = parse_mapping(
@@ -177,9 +197,9 @@ def _prepare_sftp_copy(
             task=task,
             notebooks=notebooks,
             secrets=secrets_to_collect if secrets_to_collect else None,
+            setup_task=setup_task,
         )
 
-    # DLT pipeline execution — DLT handles streaming natively
     notebook_path, notebook = _create_copy_data_notebook(
         source_definition,
         sink_definition,
@@ -206,6 +226,7 @@ def _prepare_sftp_copy(
                 name=pipeline_name,
             )
         ],
+        setup_task=setup_task,
     )
 
 
@@ -215,6 +236,7 @@ def _create_sftp_streaming_notebook(
     sink_definition: dict,
     column_mapping: list[dict],
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+    default_catalog_name: str = "wkmigrate",
 ) -> tuple[str, NotebookArtifact]:
     """
     Generates a notebook that reads from SFTP via Auto Loader and writes with Structured Streaming.
@@ -229,6 +251,7 @@ def _create_sftp_streaming_notebook(
         sink_definition: Merged sink dataset definition dictionary.
         column_mapping: Column-level mappings from source to sink.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
+        default_catalog_name: Default Unity Catalog catalog name for generated artifacts.
 
     Returns:
         Tuple of ``(notebook_path, NotebookArtifact)``.
@@ -238,12 +261,16 @@ def _create_sftp_streaming_notebook(
     sink_type = sink_definition.get("type", "delta")
     database_name = sink_definition.get("database_name", "default")
     table_name = sink_definition.get("table_name", sink_name)
-    checkpoint_path = f"/Volumes/wkmigrate/sftp/_checkpoints/{activity_key}"
+    checkpoint_path = f"/Volumes/{default_catalog_name}/sftp/_checkpoints/{activity_key}"
 
     if sink_type == "delta":
-        sink_table = f"hive_metastore.{database_name}.{table_name}"
+        sink_path = f"{default_catalog_name}.{database_name}.{table_name}"
+        sink_format = "delta"
     else:
-        sink_table = f"wkmigrate.sftp.{sink_name}"
+        sink_container = sink_definition.get("container", "")
+        sink_folder = sink_definition.get("folder_path", "")
+        sink_path = f"/Volumes/{default_catalog_name}/sftp/{sink_container}/{sink_folder}"
+        sink_format = sink_type
 
     script_lines = [
         "# Databricks notebook source",
@@ -258,7 +285,7 @@ def _create_sftp_streaming_notebook(
     script_lines.append("# Map the source columns to the target columns:")
     script_lines.append(_get_mapping(source_definition, sink_definition, column_mapping, True))
     script_lines.append("# Write to the target (streaming):")
-    script_lines.append(get_sftp_write_expression(sink_name, sink_table, checkpoint_path))
+    script_lines.append(get_sftp_write_expression(sink_name, sink_format, sink_path, checkpoint_path))
 
     notebook_content = autopep8.fix_code("\n".join(script_lines))
     notebook_path = f"/wkmigrate/copy_data_notebooks/copy_{source_name}_to_{sink_name}"
@@ -268,37 +295,41 @@ def _create_sftp_streaming_notebook(
 
 def _build_sftp_setup_notebook(
     source_definition: dict,
+    sink_definition: dict,
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+    default_catalog_name: str = "wkmigrate",
+    create_sink_volume: bool = False,
 ) -> NotebookArtifact:
     """
     Generates a one-time setup notebook for SFTP connection configuration.
 
-    The notebook creates a Unity Catalog connection to the SFTP server and
-    an external volume that exposes files from the remote path.  An operator
-    should review and execute this notebook once before running the translated
-    copy workflow.
+    The notebook creates a Unity Catalog connection to the SFTP server.
+    No volume is created for the SFTP source because volumes cannot be
+    backed by an SFTP connection.  For non-Delta sinks, an external volume
+    is created for the sink bucket/container.
 
     Args:
         source_definition: Merged source dataset properties.
+        sink_definition: Merged sink dataset properties.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
+        default_catalog_name: Default Unity Catalog catalog name for generated artifacts.
+        create_sink_volume: Whether to create a UC external volume for the sink.
 
     Returns:
         NotebookArtifact containing the setup notebook content.
     """
     source_name = source_definition.get("dataset_name", "source")
     service_name = source_definition.get("service_name", source_name)
+    auth_type = source_definition.get("authentication_type", "Basic")
 
-    # Parse host/port from the url field (e.g. "sftp://host:port")
     url = source_definition.get("url", "")
     parsed = urlparse(url)
     host = parsed.hostname or source_definition.get("host", "<SFTP_HOST>")
     port = parsed.port or source_definition.get("port", 22)
     connection_name = f"{service_name}_sftp_connection"
-    volume_path = get_sftp_file_uri(source_definition)
+    source_uri = sftp_file_uri(source_definition)
     notebook_path = f"/wkmigrate/sftp_setup/{connection_name}_setup"
 
-    # Build-time f-strings resolve host/port/connection_name here;
-    # runtime f-strings in the emitted notebook resolve local variables.
     lines = [
         "# Databricks notebook source",
         "# SFTP Connection - One-Time Setup Notebook",
@@ -311,39 +342,117 @@ def _build_sftp_setup_notebook(
         f'connection_name = "{connection_name}"',
         f'host = "{host}"',
         f"port = {port}",
-        f'user_name = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_user_name")',
-        f'password = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_password")',
-        "",
-        'spark.sql(f"""',
-        "    CREATE CONNECTION IF NOT EXISTS `{connection_name}`",
-        "    TYPE sftp",
-        "    OPTIONS (",
-        "        host '{host}',",
-        "        port '{port}',",
-        "        username '{user_name}',",
-        "        password '{password}'",
-        "    )",
-        '""")',
-        "",
-        "# COMMAND ----------",
-        "",
-        "# Step 2: Create the external volume for SFTP file access",
-        'spark.sql("""',
-        "    CREATE SCHEMA IF NOT EXISTS wkmigrate.sftp",
-        '""")',
-        "",
-        'spark.sql(f"""',
-        f"    CREATE EXTERNAL VOLUME IF NOT EXISTS wkmigrate.sftp.`{service_name}`",
-        "    LOCATION 'sftp://{host}:{port}/'",
-        "    CONNECTION `{connection_name}`",
-        '""")',
-        "",
-        f'print("SFTP connection \\"{connection_name}\\" and volume configured.")',
-        f'print("Files will be available at: {volume_path}")',
     ]
+
+    if auth_type and auth_type.lower() == "basic":
+        lines.extend(
+            [
+                f'user_name = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_user_name")',
+                f'password = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_password")',
+                "",
+                "# Escape single quotes in credentials to prevent SQL injection",
+                "user_name = user_name.replace(\"'\", \"''\")",
+                "password = password.replace(\"'\", \"''\")",
+                "",
+                'spark.sql(f"""',
+                "    CREATE CONNECTION IF NOT EXISTS `{connection_name}`",
+                "    TYPE sftp",
+                "    OPTIONS (",
+                "        host '{host}',",
+                "        port '{port}',",
+                "        user '{user_name}',",
+                "        password '{password}'",
+                "    )",
+                '""")',
+            ]
+        )
+    else:
+        warnings.warn(
+            f"SFTP authentication type '{auth_type}' is not translatable for connection '{connection_name}'. "
+            "The setup notebook contains placeholder parameters that must be filled in manually.",
+            stacklevel=2,
+        )
+        lines.extend(
+            [
+                f"# WARNING: Authentication type '{auth_type}' is not directly translatable.",
+                "# Fill in the connection options below manually.",
+                f'user_name = "<{auth_type}_USER>"',
+                f'password = "<{auth_type}_PASSWORD>"',
+                f'key_fingerprint = "<{auth_type}_KEY_FINGERPRINT>"',
+                "",
+                'spark.sql(f"""',
+                "    CREATE CONNECTION IF NOT EXISTS `{connection_name}`",
+                "    TYPE sftp",
+                "    OPTIONS (",
+                "        host '{host}',",
+                "        port '{port}',",
+                "        user '{user_name}',",
+                "        password '{password}',",
+                "        key_fingerprint '{key_fingerprint}'",
+                "    )",
+                '""")',
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "# COMMAND ----------",
+            "",
+            f"# Step 2: Verify SFTP connection",
+            f'spark.sql("""',
+            f"    CREATE SCHEMA IF NOT EXISTS {default_catalog_name}.sftp",
+            '""")',
+            "",
+            f'print("SFTP connection \\"{connection_name}\\" configured.")',
+            f'print("SFTP source URI: {source_uri}")',
+        ]
+    )
+
+    if create_sink_volume:
+        sink_container = sink_definition.get("container", "")
+        sink_provider_type = sink_definition.get("provider_type", "abfs")
+        sink_service_name = sink_definition.get("service_name", "sink")
+        volume_location = _get_sink_volume_location(sink_definition, sink_provider_type)
+        lines.extend(
+            [
+                "",
+                "# COMMAND ----------",
+                "",
+                f"# Step 3: Create external volume for the sink bucket/container",
+                f'spark.sql("""',
+                f"    CREATE EXTERNAL VOLUME IF NOT EXISTS {default_catalog_name}.sftp.`{sink_service_name}_{sink_container}`",
+                f"    LOCATION '{volume_location}'",
+                '""")',
+                "",
+                f'print("Sink volume {default_catalog_name}.sftp.{sink_service_name}_{sink_container} configured.")',
+            ]
+        )
 
     content = autopep8.fix_code("\n".join(lines))
     return NotebookArtifact(file_path=notebook_path, content=content)
+
+
+def _get_sink_volume_location(sink_definition: dict, provider_type: str) -> str:
+    """
+    Builds the cloud storage URI for a sink dataset for use as a volume location.
+
+    Args:
+        sink_definition: Sink dataset definition dictionary.
+        provider_type: Cloud provider type.
+
+    Returns:
+        Cloud storage URI for the sink container/bucket.
+    """
+    container = sink_definition.get("container", "")
+    if provider_type == "s3":
+        return f"s3://{container}"
+    if provider_type == "gcs":
+        return f"gs://{container}"
+    storage_account_name = sink_definition.get("storage_account_name", "")
+    if provider_type == "azure_blob":
+        return f"wasbs://{container}@{storage_account_name}.blob.core.windows.net/"
+    return f"abfss://{container}@{storage_account_name}.dfs.core.windows.net/"
 
 
 def _create_copy_data_notebook(

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -60,7 +60,9 @@ def prepare_copy_activity(
     source_provider_type = source_definition.get("provider_type")
 
     if source_provider_type == "sftp":
-        return _prepare_sftp_copy(activity, source_definition, sink_definition, column_mapping, secrets_to_collect, credentials_scope)
+        return _prepare_sftp_copy(
+            activity, source_definition, sink_definition, column_mapping, secrets_to_collect, credentials_scope
+        )
 
     files_to_delta_sinks = sink_definition.get("type") == "delta"
     if default_files_to_delta_sinks is not None:
@@ -236,7 +238,6 @@ def _build_sftp_setup_notebook(
 
     content = autopep8.fix_code("\n".join(lines))
     return NotebookArtifact(file_path=notebook_path, content=content)
-
 
 
 def _create_copy_data_notebook(

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -163,19 +163,42 @@ def _prepare_sftp_copy(
     )
 
     setup_notebook = _build_sftp_setup_notebook(source_definition, credentials_scope)
+    notebooks = [setup_notebook, notebook]
 
     base_task = get_base_task(activity)
+
+    if not files_to_delta_sinks:
+        task = parse_mapping(
+            {
+                **base_task,
+                "notebook_task": {"notebook_path": notebook_path},
+            }
+        )
+        return PreparedActivity(
+            task=task,
+            notebooks=notebooks,
+            secrets=secrets_to_collect if secrets_to_collect else None,
+        )
+
+    # DLT pipeline execution
+    pipeline_name = f"{activity.task_key}_pipeline"
     task = parse_mapping(
         {
             **base_task,
-            "notebook_task": {"notebook_path": notebook_path},
+            "pipeline_task": {"pipeline_id": "__PIPELINE_ID__"},
         }
     )
-
     return PreparedActivity(
         task=task,
-        notebooks=[setup_notebook, notebook],
+        notebooks=notebooks,
         secrets=secrets_to_collect if secrets_to_collect else None,
+        pipelines=[
+            PipelineInstruction(
+                task_ref=task,
+                file_path=notebook.file_path,
+                name=pipeline_name,
+            )
+        ],
     )
 
 

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -159,8 +159,6 @@ def _prepare_sftp_copy(
     base_task = get_base_task(activity)
 
     if not files_to_delta_sinks:
-        # Auto Loader requires readStream/writeStream.  Use trigger(availableNow=True)
-        # for batch-like semantics: process all available files then stop.
         notebook_path, notebook = _create_sftp_streaming_notebook(
             activity.task_key,
             source_definition,
@@ -242,7 +240,6 @@ def _create_sftp_streaming_notebook(
     table_name = sink_definition.get("table_name", sink_name)
     checkpoint_path = f"/Volumes/wkmigrate/sftp/_checkpoints/{activity_key}"
 
-    # Determine sink table reference
     if sink_type == "delta":
         sink_table = f"hive_metastore.{database_name}.{table_name}"
     else:
@@ -260,7 +257,7 @@ def _create_sftp_streaming_notebook(
     script_lines.append(get_read_expression(source_definition))
     script_lines.append("# Map the source columns to the target columns:")
     script_lines.append(_get_mapping(source_definition, sink_definition, column_mapping, True))
-    script_lines.append("# Write to the target using Structured Streaming with trigger(availableNow=True):")
+    script_lines.append("# Write to the target (streaming):")
     script_lines.append(get_sftp_write_expression(sink_name, sink_table, checkpoint_path))
 
     notebook_content = autopep8.fix_code("\n".join(script_lines))
@@ -300,12 +297,8 @@ def _build_sftp_setup_notebook(
     volume_path = get_sftp_file_uri(source_definition)
     notebook_path = f"/wkmigrate/sftp_setup/{connection_name}_setup"
 
-    # NOTE: This notebook mixes two kinds of f-string interpolation:
-    # - Build-time (Python f-strings here): {host}, {port}, {connection_name},
-    #   {credentials_scope}, {service_name} are resolved when generating the notebook.
-    # - Runtime (f-strings in the emitted notebook code): {connection_name}, {host},
-    #   {port}, {user_name}, {password} inside spark.sql(f"...") are resolved when
-    #   the notebook executes in Databricks, referencing local Python variables.
+    # Build-time f-strings resolve host/port/connection_name here;
+    # runtime f-strings in the emitted notebook resolve local variables.
     lines = [
         "# Databricks notebook source",
         "# SFTP Connection - One-Time Setup Notebook",

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -270,9 +270,7 @@ def _create_sftp_streaming_notebook(
     checkpoint_path = f"/Volumes/{default_catalog_name}/sftp/_checkpoints/{activity_key}"
 
     if sink_type == "delta":
-        raise ValueError(
-            "Delta sinks must use the DLT pipeline path, not the streaming notebook"
-        )
+        raise ValueError("Delta sinks must use the DLT pipeline path, not the streaming notebook")
 
     sink_container = sink_definition.get("container", "")
     sink_folder = sink_definition.get("folder_path", "")

--- a/src/wkmigrate/preparers/copy_activity_preparer.py
+++ b/src/wkmigrate/preparers/copy_activity_preparer.py
@@ -22,6 +22,7 @@ from wkmigrate.code_generator import (
     get_file_uri,
     get_option_expressions,
     get_read_expression,
+    get_sftp_file_uri,
 )
 from wkmigrate.models.ir.pipeline import CopyActivity
 from wkmigrate.models.workflows.artifacts import NotebookArtifact, PreparedActivity
@@ -55,6 +56,11 @@ def prepare_copy_activity(
     data_source_secrets = collect_data_source_secrets(source_definition, credentials_scope)
     data_sink_secrets = collect_data_source_secrets(sink_definition, credentials_scope)
     secrets_to_collect = data_source_secrets + data_sink_secrets
+
+    source_provider_type = source_definition.get("provider_type")
+
+    if source_provider_type == "sftp":
+        return _prepare_sftp_copy(activity, source_definition, sink_definition, column_mapping, secrets_to_collect, credentials_scope)
 
     files_to_delta_sinks = sink_definition.get("type") == "delta"
     if default_files_to_delta_sinks is not None:
@@ -104,6 +110,133 @@ def prepare_copy_activity(
             )
         ],
     )
+
+
+def _prepare_sftp_copy(
+    activity: CopyActivity,
+    source_definition: dict,
+    sink_definition: dict,
+    column_mapping: list[dict],
+    secrets_to_collect: list,
+    credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+) -> PreparedActivity:
+    """
+    Builds tasks and artifacts for a Copy activity that reads from an SFTP source.
+
+    SFTP sources use Auto Loader to stream files from a Unity Catalog volume
+    backed by an SFTP connection.  In addition to the main copy notebook, a
+    one-time setup notebook is generated to create the UC connection and
+    external volume.
+
+    Args:
+        activity: Copy activity definition from the translator layer.
+        source_definition: Merged source dataset properties.
+        sink_definition: Merged sink dataset properties.
+        column_mapping: Column-level mappings from source to sink.
+        secrets_to_collect: Secret instructions for the source and sink.
+        credentials_scope: Name of the Databricks secret scope used for storing credentials.
+
+    Returns:
+        PreparedActivity with notebook tasks and setup notebook artifacts.
+    """
+    notebook_path, notebook = _create_copy_data_notebook(
+        source_definition,
+        sink_definition,
+        column_mapping,
+        files_to_delta_sinks=False,
+        credentials_scope=credentials_scope,
+    )
+
+    setup_notebook = _build_sftp_setup_notebook(source_definition, credentials_scope)
+
+    base_task = get_base_task(activity)
+    task = parse_mapping(
+        {
+            **base_task,
+            "notebook_task": {"notebook_path": notebook_path},
+        }
+    )
+
+    return PreparedActivity(
+        task=task,
+        notebooks=[setup_notebook, notebook],
+        secrets=secrets_to_collect if secrets_to_collect else None,
+    )
+
+
+def _build_sftp_setup_notebook(
+    source_definition: dict,
+    credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+) -> NotebookArtifact:
+    """
+    Generates a one-time setup notebook for SFTP connection configuration.
+
+    The notebook creates a Unity Catalog connection to the SFTP server and
+    an external volume that exposes files from the remote path.  An operator
+    should review and execute this notebook once before running the translated
+    copy workflow.
+
+    Args:
+        source_definition: Merged source dataset properties.
+        credentials_scope: Name of the Databricks secret scope used for storing credentials.
+
+    Returns:
+        NotebookArtifact containing the setup notebook content.
+    """
+    source_name = source_definition.get("dataset_name", "source")
+    service_name = source_definition.get("service_name", source_name)
+    host = source_definition.get("host", "<SFTP_HOST>")
+    port = source_definition.get("port", 22)
+    connection_name = f"{service_name}_sftp_connection"
+    volume_path = get_sftp_file_uri(source_definition)
+    notebook_path = f"/wkmigrate/sftp_setup/{connection_name}_setup"
+
+    lines = [
+        "# Databricks notebook source",
+        "# SFTP Connection - One-Time Setup Notebook",
+        f"# Source: {source_name} ({host}:{port})",
+        f"# Connection: {connection_name}",
+        "",
+        "# COMMAND ----------",
+        "",
+        "# Step 1: Create the Unity Catalog connection to the SFTP server",
+        f'connection_name = "{connection_name}"',
+        f'host = "{host}"',
+        f'port = {port}',
+        f'user_name = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_user_name")',
+        f'password = dbutils.secrets.get(scope="{credentials_scope}", key="{service_name}_password")',
+        "",
+        "spark.sql(f\"\"\"",
+        "    CREATE CONNECTION IF NOT EXISTS `{connection_name}`",
+        "    TYPE sftp",
+        "    OPTIONS (",
+        "        host '{host}',",
+        "        port '{port}',",
+        "        username '{user_name}',",
+        "        password '{password}'",
+        "    )",
+        "\"\"\")",
+        "",
+        "# COMMAND ----------",
+        "",
+        "# Step 2: Create the external volume for SFTP file access",
+        'spark.sql("""',
+        "    CREATE SCHEMA IF NOT EXISTS wkmigrate.sftp",
+        '""")',
+        "",
+        "spark.sql(f\"\"\"",
+        f'    CREATE EXTERNAL VOLUME IF NOT EXISTS wkmigrate.sftp.`{service_name}`',
+        "    LOCATION 'sftp://{host}:{port}/'",
+        "    CONNECTION `{connection_name}`",
+        "\"\"\")",
+        "",
+        f'print("SFTP connection \\"{connection_name}\\" and volume configured.")',
+        f'print("Files will be available at: {volume_path}")',
+    ]
+
+    content = autopep8.fix_code("\n".join(lines))
+    return NotebookArtifact(file_path=notebook_path, content=content)
+
 
 
 def _create_copy_data_notebook(

--- a/src/wkmigrate/preparers/preparer.py
+++ b/src/wkmigrate/preparers/preparer.py
@@ -41,6 +41,7 @@ def prepare_workflow(
     pipeline: Pipeline,
     files_to_delta_sinks: bool | None = None,
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+    default_catalog_name: str = "wkmigrate",
 ) -> PreparedWorkflow:
     """
     Prepares a pipeline internal representation for creation as a Databricks Lakeflow job.
@@ -49,11 +50,14 @@ def prepare_workflow(
         pipeline: Pipeline internal representation to prepare.
         files_to_delta_sinks: Overrides the inferred Files-to-Delta behavior when set.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
+        default_catalog_name: Default Unity Catalog catalog name for generated artifacts.
 
     Returns:
         Prepared workflow containing the Databricks job payload and supporting artifacts for the pipeline.
     """
-    activities = [prepare_activity(task, files_to_delta_sinks, credentials_scope) for task in pipeline.tasks]
+    activities = [
+        prepare_activity(task, files_to_delta_sinks, credentials_scope, default_catalog_name) for task in pipeline.tasks
+    ]
     return PreparedWorkflow(pipeline=pipeline, activities=activities)
 
 
@@ -61,6 +65,7 @@ def prepare_activity(
     activity: Activity,
     default_files_to_delta_sinks: bool | None,
     credentials_scope: str = DEFAULT_CREDENTIALS_SCOPE,
+    default_catalog_name: str = "wkmigrate",
 ) -> PreparedActivity:
     """
     Prepares an activity internal representation for creation as a Databricks Lakeflow job task.
@@ -69,6 +74,7 @@ def prepare_activity(
         activity: Activity internal representation to prepare.
         default_files_to_delta_sinks: Whether to use the default files-to-delta sinks behavior.
         credentials_scope: Name of the Databricks secret scope used for storing credentials.
+        default_catalog_name: Default Unity Catalog catalog name for generated artifacts.
 
     Returns:
         Prepared activity containing the task configuration and any associated artifacts.
@@ -86,7 +92,7 @@ def prepare_activity(
     if isinstance(activity, RunJobActivity):
         return prepare_run_job_activity(activity, default_files_to_delta_sinks, credentials_scope)
     if isinstance(activity, CopyActivity):
-        return prepare_copy_activity(activity, default_files_to_delta_sinks, credentials_scope)
+        return prepare_copy_activity(activity, default_files_to_delta_sinks, credentials_scope, default_catalog_name)
     if isinstance(activity, LookupActivity):
         return prepare_lookup_activity(activity, credentials_scope)
     if isinstance(activity, WebActivity):

--- a/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
+++ b/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
@@ -70,6 +70,8 @@ def translate_file_dataset(
 
     if provider_type == "abfs":
         return _translate_abfs_file_dataset(dataset_type, dataset, provider_type)
+    if provider_type == "sftp":
+        return _translate_sftp_file_dataset(dataset_type, dataset, provider_type)
     return _translate_cloud_file_dataset(dataset_type, dataset, provider_type)
 
 
@@ -116,6 +118,55 @@ def _translate_abfs_file_dataset(
         storage_account_name=linked_service.storage_account_name,
         service_name=linked_service.service_name,
         url=linked_service.url,
+        format_options=format_options,
+        provider_type=provider_type,
+    )
+
+
+def _translate_sftp_file_dataset(
+    dataset_type: str, dataset: dict, provider_type: str
+) -> FileDataset | UnsupportedValue:
+    """Translate an SFTP-backed file dataset.
+
+    SFTP datasets do not use a container or bucket.  The file path is
+    derived from the location's ``folder_path`` and ``file_name`` fields.
+    The linked service provides connection metadata (host, port,
+    authentication).
+
+    Args:
+        dataset_type: ADF dataset type (e.g. ``"DelimitedText"``, ``"Parquet"``).
+        dataset: Raw dataset definition from Azure Data Factory.
+        provider_type: Cloud provider identifier (always ``"sftp"`` for this translator).
+
+    Returns:
+        File dataset as a ``FileDataset`` object, or ``UnsupportedValue`` when parsing fails.
+    """
+    properties = dataset.get("properties", {})
+
+    folder_path = parse_cloud_file_path(properties)
+    if isinstance(folder_path, UnsupportedValue):
+        return UnsupportedValue(value=dataset, message=folder_path.message)
+
+    linked_service_definition = get_linked_service_definition(dataset)
+    if isinstance(linked_service_definition, UnsupportedValue):
+        return UnsupportedValue(value=dataset, message=linked_service_definition.message)
+
+    linked_service = translate_sftp_spec(linked_service_definition)
+    if isinstance(linked_service, UnsupportedValue):
+        return UnsupportedValue(value=dataset, message=linked_service.message)
+
+    format_options = parse_format_options(dataset_type, dataset)
+    if isinstance(format_options, UnsupportedValue):
+        return UnsupportedValue(value=dataset, message=format_options.message)
+
+    return FileDataset(
+        dataset_name=dataset.get("name", "DATASET_NAME_NOT_PROVIDED"),
+        dataset_type=dataset_type,
+        container=None,
+        folder_path=folder_path,
+        storage_account_name=None,
+        service_name=linked_service.service_name,
+        url=f"sftp://{linked_service.host}:{linked_service.port}",
         format_options=format_options,
         provider_type=provider_type,
     )

--- a/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
+++ b/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
@@ -22,12 +22,14 @@ from wkmigrate.translators.linked_service_translators import (
     translate_azure_blob_spec,
     translate_gcs_spec,
     translate_s3_spec,
+    translate_sftp_spec,
 )
 
 _CLOUD_TRANSLATORS: dict[str, Callable] = {
     "s3": translate_s3_spec,
     "gcs": translate_gcs_spec,
     "azure_blob": translate_azure_blob_spec,
+    "sftp": translate_sftp_spec,
 }
 
 

--- a/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
+++ b/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
@@ -29,7 +29,6 @@ _CLOUD_TRANSLATORS: dict[str, Callable] = {
     "s3": translate_s3_spec,
     "gcs": translate_gcs_spec,
     "azure_blob": translate_azure_blob_spec,
-    "sftp": translate_sftp_spec,
 }
 
 

--- a/src/wkmigrate/translators/linked_service_translators/__init__.py
+++ b/src/wkmigrate/translators/linked_service_translators/__init__.py
@@ -8,6 +8,9 @@ Each translator validates required fields, coerces connection settings, and emit
 from wkmigrate.translators.linked_service_translators.databricks_linked_service_translator import (
     translate_databricks_cluster_spec,
 )
+from wkmigrate.translators.linked_service_translators.sftp_linked_service_translator import (
+    translate_sftp_spec,
+)
 from wkmigrate.translators.linked_service_translators.sql_linked_service_translator import (
     translate_mysql_spec,
     translate_oracle_spec,
@@ -30,5 +33,6 @@ __all__ = [
     "translate_oracle_spec",
     "translate_postgresql_spec",
     "translate_s3_spec",
+    "translate_sftp_spec",
     "translate_sql_server_spec",
 ]

--- a/src/wkmigrate/translators/linked_service_translators/sftp_linked_service_translator.py
+++ b/src/wkmigrate/translators/linked_service_translators/sftp_linked_service_translator.py
@@ -1,0 +1,43 @@
+"""Translator for SFTP linked service definitions.
+
+This module normalizes ADF SFTP linked-service payloads into
+``SftpLinkedService`` objects.
+"""
+
+from uuid import uuid4
+
+from wkmigrate.models.ir.linked_services import SftpLinkedService
+from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.utils import get_value_or_unsupported
+
+_DEFAULT_SFTP_PORT = 22
+
+
+def translate_sftp_spec(sftp_spec: dict) -> SftpLinkedService | UnsupportedValue:
+    """
+    Parses an SFTP linked service definition into an ``SftpLinkedService`` object.
+
+    Args:
+        sftp_spec: Linked-service definition from Azure Data Factory.
+
+    Returns:
+        SFTP linked-service metadata as an ``SftpLinkedService`` object.
+    """
+    if not sftp_spec:
+        return UnsupportedValue(value=sftp_spec, message="Missing SFTP linked service definition")
+
+    properties = sftp_spec.get("properties", {})
+    host = get_value_or_unsupported(properties, "host", "SFTP linked service properties")
+    if isinstance(host, UnsupportedValue):
+        return UnsupportedValue(value=sftp_spec, message=host.message)
+
+    port = properties.get("port", _DEFAULT_SFTP_PORT)
+
+    return SftpLinkedService(
+        service_name=sftp_spec.get("name", str(uuid4())),
+        service_type="sftp",
+        host=host,
+        port=port,
+        user_name=properties.get("user_name"),
+        authentication_type=properties.get("authentication_type"),
+    )

--- a/tests/unit/test_preparer.py
+++ b/tests/unit/test_preparer.py
@@ -21,7 +21,6 @@ from wkmigrate.preparers.preparer import prepare_workflow
 from wkmigrate.preparers.run_job_activity_preparer import prepare_run_job_activity
 from wkmigrate.preparers.web_activity_preparer import prepare_web_activity
 
-
 _CSV_SOURCE = {
     "type": "csv",
     "dataset_name": "my_csv",

--- a/tests/unit/test_sftp_support.py
+++ b/tests/unit/test_sftp_support.py
@@ -6,6 +6,7 @@ code generator helpers, and copy activity preparer for SFTP sources.
 
 from __future__ import annotations
 
+import warnings
 
 from wkmigrate.code_generator import (
     DEFAULT_CREDENTIALS_SCOPE,
@@ -25,7 +26,10 @@ from wkmigrate.parsers.dataset_parsers import (
     DATASET_PROVIDER_SECRETS,
     collect_data_source_secrets,
 )
-from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
+from wkmigrate.preparers.copy_activity_preparer import (
+    _build_sftp_setup_notebook,
+    prepare_copy_activity,
+)
 from wkmigrate.translators.dataset_translators import translate_dataset, translate_file_dataset
 from wkmigrate.translators.linked_service_translators import translate_sftp_spec
 
@@ -625,3 +629,87 @@ def test_sftp_copy_end_to_end_from_file_dataset_ir() -> None:
     assert "prod.sftp.example.com" in setup_content
     assert "2222" in setup_content
     assert "CREATE CONNECTION" in setup_content
+
+
+def test_sftp_setup_notebook_warns_on_unsupported_auth() -> None:
+    """Non-Basic auth emits a warning and generates placeholder credentials."""
+    source_definition = {
+        "type": "csv",
+        "dataset_name": "sftp_ssh_key",
+        "service_name": "sftp-key-server",
+        "url": "sftp://sftp.example.com:22",
+        "folder_path": "uploads/data.csv",
+        "provider_type": "sftp",
+        "authentication_type": "SshPublicKey",
+    }
+    sink_definition = {
+        "type": "csv",
+        "dataset_name": "my_sink",
+        "service_name": "my_blob",
+        "container": "output",
+        "folder_path": "data",
+    }
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        notebook = _build_sftp_setup_notebook(
+            source_definition,
+            sink_definition,
+            credentials_scope="wkmigrate",
+            default_catalog_name="wkmigrate",
+        )
+
+    # A warning must have been emitted about the unsupported auth type
+    assert len(caught) == 1
+    assert "SshPublicKey" in str(caught[0].message)
+    assert "not translatable" in str(caught[0].message)
+
+    # The generated notebook must contain placeholder markers and key_fingerprint
+    assert "key_fingerprint" in notebook.content
+    assert "<SshPublicKey_USER>" in notebook.content
+    assert "<SshPublicKey_PASSWORD>" in notebook.content
+    assert "<SshPublicKey_KEY_FINGERPRINT>" in notebook.content
+
+
+def test_sftp_copy_delta_sink_always_uses_dlt_pipeline() -> None:
+    """Delta sinks must always route to DLT pipeline, even when default_files_to_delta_sinks=False."""
+    delta_sink = {
+        "type": "delta",
+        "dataset_name": "my_delta_table",
+        "service_name": "my_lakehouse",
+        "database_name": "analytics",
+        "table_name": "events",
+    }
+    activity = CopyActivity(
+        name="CopySftpToDelta",
+        task_key="copysftptodelta",
+        source_dataset=_SFTP_SOURCE,
+        sink_dataset=delta_sink,
+        source_properties={"type": "csv"},
+        sink_properties={"type": "delta"},
+        column_mapping=[
+            ColumnMapping(
+                source_column_name="col_a",
+                sink_column_name="col_a",
+                sink_column_type="string",
+            ),
+        ],
+    )
+
+    # Even with default_files_to_delta_sinks=False, Delta sink must use DLT pipeline
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=False)
+
+    assert "pipeline_task" in result.task
+    assert result.pipelines is not None
+    assert len(result.pipelines) == 1
+
+
+def test_sftp_setup_notebook_escapes_host_in_sql() -> None:
+    """Setup notebook escapes single quotes in host to prevent SQL injection."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    setup_content = result.notebooks[0].content
+    # host must also be escaped, not just user_name and password
+    assert setup_content.count("replace(\"'\", \"''\")") == 3

--- a/tests/unit/test_sftp_support.py
+++ b/tests/unit/test_sftp_support.py
@@ -6,7 +6,6 @@ code generator helpers, and copy activity preparer for SFTP sources.
 
 from __future__ import annotations
 
-import pytest
 
 from wkmigrate.code_generator import (
     DEFAULT_CREDENTIALS_SCOPE,
@@ -29,7 +28,6 @@ from wkmigrate.parsers.dataset_parsers import (
 from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
 from wkmigrate.translators.dataset_translators import translate_dataset, translate_file_dataset
 from wkmigrate.translators.linked_service_translators import translate_sftp_spec
-
 
 # ---------------------------------------------------------------------------
 # SFTP linked service translator tests

--- a/tests/unit/test_sftp_support.py
+++ b/tests/unit/test_sftp_support.py
@@ -15,6 +15,7 @@ from wkmigrate.code_generator import (
     get_sftp_file_uri,
     get_sftp_options,
     get_sftp_read_expression,
+    get_sftp_write_expression,
 )
 from wkmigrate.models.ir.datasets import FileDataset
 from wkmigrate.models.ir.linked_services import SftpLinkedService
@@ -298,8 +299,8 @@ def test_get_sftp_options() -> None:
 
     joined = "\n".join(lines)
     assert "sftp_csv_options = {}" in joined
-    assert 'cloudFiles.connectionName' in joined
-    assert 'my_sftp_sftp_connection' in joined
+    assert "cloudFiles.connectionName" in joined
+    assert "my_sftp_sftp_connection" in joined
 
 
 def test_get_option_expressions_sftp_dispatches() -> None:
@@ -335,6 +336,36 @@ def test_get_sftp_read_expression() -> None:
     assert "sftp_csv_df" in expr
 
 
+def test_get_sftp_read_expression_uses_readstream() -> None:
+    """get_sftp_read_expression uses spark.readStream (not spark.read)."""
+    definition = {
+        "dataset_name": "sftp_csv",
+        "type": "csv",
+        "service_name": "my_sftp",
+        "folder_path": "data/incoming",
+        "provider_type": "sftp",
+    }
+    expr = get_sftp_read_expression(definition)
+
+    assert "readStream" in expr
+    assert "spark.read.format" not in expr
+
+
+def test_get_sftp_write_expression() -> None:
+    """get_sftp_write_expression generates a streaming write with trigger(availableNow=True)."""
+    expr = get_sftp_write_expression(
+        dataset_name="my_sink",
+        sink_table="catalog.schema.target_table",
+        checkpoint_path="/Volumes/wkmigrate/sftp/_checkpoints/my_task",
+    )
+
+    assert "my_sink_df.writeStream" in expr
+    assert "availableNow=True" in expr
+    assert "checkpointLocation" in expr
+    assert "/Volumes/wkmigrate/sftp/_checkpoints/my_task" in expr
+    assert 'toTable("catalog.schema.target_table")' in expr
+
+
 def test_get_read_expression_sftp_dispatches() -> None:
     """get_read_expression dispatches to SFTP read when provider_type is sftp."""
     definition = {
@@ -348,6 +379,7 @@ def test_get_read_expression_sftp_dispatches() -> None:
 
     assert "cloudFiles" in expr
     assert "sftp_csv_df" in expr
+    assert "readStream" in expr
 
 
 # ---------------------------------------------------------------------------
@@ -470,15 +502,17 @@ def test_sftp_copy_preparer_custom_credentials_scope() -> None:
     assert DEFAULT_CREDENTIALS_SCOPE not in setup_content
 
 
-def test_sftp_copy_preparer_uses_batch_read() -> None:
-    """SFTP copy notebook uses spark.read (batch), not spark.readStream."""
+def test_sftp_copy_preparer_uses_streaming() -> None:
+    """SFTP copy notebook uses readStream + writeStream with trigger(availableNow=True)."""
     activity = _make_sftp_copy_activity()
 
     result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
 
     copy_notebook = result.notebooks[1]
-    assert "spark.read.format" in copy_notebook.content
-    assert "readStream" not in copy_notebook.content
+    assert "readStream" in copy_notebook.content
+    assert "writeStream" in copy_notebook.content
+    assert "availableNow=True" in copy_notebook.content
+    assert "checkpointLocation" in copy_notebook.content
 
 
 def test_sftp_copy_preparer_respects_files_to_delta_sinks() -> None:

--- a/tests/unit/test_sftp_support.py
+++ b/tests/unit/test_sftp_support.py
@@ -1,0 +1,471 @@
+"""Tests for SFTP Copy activity support.
+
+This module tests the SFTP linked service translator, dataset translation,
+code generator helpers, and copy activity preparer for SFTP sources.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wkmigrate.code_generator import (
+    DEFAULT_CREDENTIALS_SCOPE,
+    get_option_expressions,
+    get_read_expression,
+    get_sftp_file_uri,
+    get_sftp_options,
+    get_sftp_read_expression,
+)
+from wkmigrate.models.ir.datasets import FileDataset
+from wkmigrate.models.ir.linked_services import SftpLinkedService
+from wkmigrate.models.ir.pipeline import ColumnMapping, CopyActivity
+from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.parsers.dataset_parsers import (
+    CLOUD_LOCATION_TYPES,
+    DATASET_PROVIDER_SECRETS,
+    collect_data_source_secrets,
+)
+from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
+from wkmigrate.translators.dataset_translators import translate_dataset, translate_file_dataset
+from wkmigrate.translators.linked_service_translators import translate_sftp_spec
+
+
+# ---------------------------------------------------------------------------
+# SFTP linked service translator tests
+# ---------------------------------------------------------------------------
+
+
+def test_translate_sftp_spec_full_configuration() -> None:
+    """Test translation of SFTP linked service with full configuration."""
+    spec = {
+        "name": "sftp-server-1",
+        "properties": {
+            "host": "sftp.example.com",
+            "port": 2222,
+            "user_name": "sftpuser",
+            "authentication_type": "Basic",
+        },
+    }
+    result = translate_sftp_spec(spec)
+
+    assert isinstance(result, SftpLinkedService)
+    assert result.service_name == "sftp-server-1"
+    assert result.service_type == "sftp"
+    assert result.host == "sftp.example.com"
+    assert result.port == 2222
+    assert result.user_name == "sftpuser"
+    assert result.authentication_type == "Basic"
+
+
+def test_translate_sftp_spec_minimal_configuration() -> None:
+    """Test translation of SFTP linked service with minimal configuration."""
+    spec = {
+        "name": "sftp-minimal",
+        "properties": {
+            "host": "192.168.1.100",
+        },
+    }
+    result = translate_sftp_spec(spec)
+
+    assert isinstance(result, SftpLinkedService)
+    assert result.service_name == "sftp-minimal"
+    assert result.host == "192.168.1.100"
+    assert result.port == 22
+    assert result.user_name is None
+    assert result.authentication_type is None
+
+
+def test_translate_sftp_spec_missing_host_returns_unsupported() -> None:
+    """Test that missing host returns UnsupportedValue."""
+    spec = {
+        "name": "sftp-no-host",
+        "properties": {
+            "port": 22,
+        },
+    }
+    result = translate_sftp_spec(spec)
+
+    assert isinstance(result, UnsupportedValue)
+    assert "host" in result.message
+
+
+def test_translate_sftp_spec_null_returns_unsupported() -> None:
+    """Test that null input returns UnsupportedValue."""
+    result = translate_sftp_spec({})
+
+    assert isinstance(result, UnsupportedValue)
+    assert "SFTP" in result.message
+
+
+def test_translate_sftp_spec_none_returns_unsupported() -> None:
+    """Test that None input returns UnsupportedValue."""
+    result = translate_sftp_spec(None)
+
+    assert isinstance(result, UnsupportedValue)
+    assert "SFTP" in result.message
+
+
+def test_translate_sftp_spec_generates_uuid_when_no_name() -> None:
+    """Test that UUID is generated when no name is provided."""
+    spec = {"properties": {"host": "sftp.example.com"}}
+    result = translate_sftp_spec(spec)
+
+    assert isinstance(result, SftpLinkedService)
+    assert result.service_name is not None
+    assert len(result.service_name) > 0
+
+
+# ---------------------------------------------------------------------------
+# SFTP dataset translator tests
+# ---------------------------------------------------------------------------
+
+
+def _build_sftp_dataset(
+    dataset_type: str = "DelimitedText",
+    dataset_name: str = "sftp_csv_dataset",
+    folder_path: str = "uploads",
+    file_name: str = "data.csv",
+    linked_service: dict | None = None,
+) -> dict:
+    """Build an SFTP file dataset definition for testing."""
+    if linked_service is None:
+        linked_service = {
+            "name": "sftp-server-1",
+            "properties": {
+                "host": "sftp.example.com",
+                "port": 22,
+                "user_name": "sftpuser",
+                "authentication_type": "Basic",
+            },
+        }
+    return {
+        "name": dataset_name,
+        "properties": {
+            "type": dataset_type,
+            "location": {
+                "type": "SftpLocation",
+                "folder_path": folder_path,
+                "file_name": file_name,
+            },
+        },
+        "linked_service_definition": linked_service,
+    }
+
+
+def test_sftp_location_in_cloud_location_types() -> None:
+    """SftpLocation is registered in CLOUD_LOCATION_TYPES."""
+    assert "SftpLocation" in CLOUD_LOCATION_TYPES
+    assert CLOUD_LOCATION_TYPES["SftpLocation"] == "sftp"
+
+
+def test_translate_sftp_dataset_csv() -> None:
+    """Test SFTP dataset translation with DelimitedText format."""
+    dataset = _build_sftp_dataset()
+    result = translate_file_dataset("DelimitedText", dataset, "sftp")
+
+    assert isinstance(result, FileDataset)
+    assert result.dataset_name == "sftp_csv_dataset"
+    assert result.dataset_type == "DelimitedText"
+    assert result.folder_path == "uploads/data.csv"
+    assert result.service_name == "sftp-server-1"
+    assert result.provider_type == "sftp"
+
+
+def test_translate_sftp_dataset_parquet() -> None:
+    """Test SFTP dataset translation with Parquet format."""
+    dataset = _build_sftp_dataset(
+        dataset_type="Parquet",
+        dataset_name="sftp_parquet_dataset",
+        folder_path="warehouse",
+        file_name="events.parquet",
+    )
+    result = translate_file_dataset("Parquet", dataset, "sftp")
+
+    assert isinstance(result, FileDataset)
+    assert result.dataset_name == "sftp_parquet_dataset"
+    assert result.dataset_type == "Parquet"
+    assert result.provider_type == "sftp"
+
+
+def test_translate_sftp_dataset_no_folder() -> None:
+    """Test SFTP dataset with no folder path."""
+    dataset = _build_sftp_dataset(folder_path="", file_name="root_file.csv")
+    result = translate_file_dataset("DelimitedText", dataset, "sftp")
+
+    assert isinstance(result, FileDataset)
+    assert result.folder_path == "root_file.csv"
+
+
+def test_translate_sftp_dataset_null_returns_unsupported() -> None:
+    """Test null SFTP dataset returns UnsupportedValue."""
+    result = translate_file_dataset("DelimitedText", {}, "sftp")
+
+    assert isinstance(result, UnsupportedValue)
+    assert "sftp" in result.message.lower()
+
+
+def test_translate_sftp_dataset_missing_linked_service_host() -> None:
+    """Test SFTP dataset with missing host in linked service returns UnsupportedValue."""
+    dataset = _build_sftp_dataset(
+        linked_service={
+            "name": "sftp-no-host",
+            "properties": {"port": 22},
+        },
+    )
+    result = translate_file_dataset("DelimitedText", dataset, "sftp")
+
+    assert isinstance(result, UnsupportedValue)
+    assert "host" in result.message
+
+
+def test_translate_dataset_dispatches_sftp() -> None:
+    """Test that translate_dataset correctly dispatches SftpLocation."""
+    dataset = _build_sftp_dataset()
+    result = translate_dataset(dataset)
+
+    assert isinstance(result, FileDataset)
+    assert result.dataset_name == "sftp_csv_dataset"
+    assert result.provider_type == "sftp"
+
+
+# ---------------------------------------------------------------------------
+# SFTP secrets registry tests
+# ---------------------------------------------------------------------------
+
+
+def test_sftp_provider_secrets_registered() -> None:
+    """SFTP provider secrets include user_name and password."""
+    assert "sftp" in DATASET_PROVIDER_SECRETS
+    assert "user_name" in DATASET_PROVIDER_SECRETS["sftp"]
+    assert "password" in DATASET_PROVIDER_SECRETS["sftp"]
+
+
+def test_collect_sftp_secrets() -> None:
+    """collect_data_source_secrets returns SFTP credential instructions."""
+    definition = {
+        "type": "csv",
+        "service_name": "sftp-server-1",
+        "provider_type": "sftp",
+        "user_name": "sftpuser",
+        "password": "s3cret",
+    }
+    secrets = collect_data_source_secrets(definition)
+
+    assert len(secrets) == 2
+    keys = {s.key for s in secrets}
+    assert "sftp-server-1_user_name" in keys
+    assert "sftp-server-1_password" in keys
+
+
+def test_collect_sftp_secrets_custom_scope() -> None:
+    """collect_data_source_secrets respects custom credentials_scope for SFTP."""
+    definition = {
+        "type": "csv",
+        "service_name": "sftp-server-1",
+        "provider_type": "sftp",
+    }
+    secrets = collect_data_source_secrets(definition, credentials_scope="custom_vault")
+
+    for secret in secrets:
+        assert secret.scope == "custom_vault"
+
+
+# ---------------------------------------------------------------------------
+# SFTP code generator tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_sftp_file_uri() -> None:
+    """get_sftp_file_uri builds a volume path."""
+    definition = {
+        "service_name": "my_sftp",
+        "folder_path": "data/incoming",
+    }
+    uri = get_sftp_file_uri(definition)
+
+    assert uri == "/Volumes/wkmigrate/sftp/my_sftp/data/incoming"
+
+
+def test_get_sftp_options() -> None:
+    """get_sftp_options generates connection_name and format options."""
+    definition = {
+        "dataset_name": "sftp_csv",
+        "service_name": "my_sftp",
+        "header": "true",
+        "sep": ",",
+    }
+    lines = get_sftp_options(definition, "csv")
+
+    joined = "\n".join(lines)
+    assert "sftp_csv_options = {}" in joined
+    assert 'connection_name' in joined
+    assert 'my_sftp_sftp_connection' in joined
+
+
+def test_get_option_expressions_sftp_dispatches() -> None:
+    """get_option_expressions dispatches to SFTP options when provider_type is sftp."""
+    definition = {
+        "dataset_name": "sftp_csv",
+        "service_name": "my_sftp",
+        "type": "csv",
+        "provider_type": "sftp",
+    }
+    lines = get_option_expressions(definition)
+
+    joined = "\n".join(lines)
+    assert "sftp_csv_options = {}" in joined
+    assert "connection_name" in joined
+
+
+def test_get_sftp_read_expression() -> None:
+    """get_sftp_read_expression uses Auto Loader (cloudFiles)."""
+    definition = {
+        "dataset_name": "sftp_csv",
+        "type": "csv",
+        "service_name": "my_sftp",
+        "folder_path": "data/incoming",
+        "provider_type": "sftp",
+    }
+    expr = get_sftp_read_expression(definition)
+
+    assert "cloudFiles" in expr
+    assert "cloudFiles.format" in expr
+    assert "csv" in expr
+    assert "/Volumes/wkmigrate/sftp/my_sftp/data/incoming" in expr
+    assert "sftp_csv_df" in expr
+
+
+def test_get_read_expression_sftp_dispatches() -> None:
+    """get_read_expression dispatches to SFTP read when provider_type is sftp."""
+    definition = {
+        "dataset_name": "sftp_csv",
+        "type": "csv",
+        "service_name": "my_sftp",
+        "folder_path": "uploads",
+        "provider_type": "sftp",
+    }
+    expr = get_read_expression(definition)
+
+    assert "cloudFiles" in expr
+    assert "sftp_csv_df" in expr
+
+
+# ---------------------------------------------------------------------------
+# SFTP copy activity preparer tests
+# ---------------------------------------------------------------------------
+
+
+_SFTP_SOURCE = {
+    "type": "csv",
+    "dataset_name": "sftp_csv_source",
+    "service_name": "sftp-server-1",
+    "host": "sftp.example.com",
+    "port": 22,
+    "folder_path": "uploads/data.csv",
+    "provider_type": "sftp",
+    "header": "true",
+    "sep": ",",
+}
+
+_CSV_SINK = {
+    "type": "csv",
+    "dataset_name": "my_sink_csv",
+    "service_name": "my_blob",
+    "storage_account_name": "mystorageacct",
+    "container": "curated",
+    "folder_path": "data/output",
+}
+
+
+def _make_sftp_copy_activity(name: str = "CopySftpToCsv") -> CopyActivity:
+    return CopyActivity(
+        name=name,
+        task_key=name.lower(),
+        source_dataset=_SFTP_SOURCE,
+        sink_dataset=_CSV_SINK,
+        source_properties={"type": "csv"},
+        sink_properties={"type": "csv"},
+        column_mapping=[
+            ColumnMapping(
+                source_column_name="col_a",
+                sink_column_name="col_a",
+                sink_column_type="string",
+            ),
+        ],
+    )
+
+
+def test_sftp_copy_preparer_produces_setup_notebook() -> None:
+    """SFTP copy produces both a setup notebook and a copy notebook."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    assert result.notebooks is not None
+    assert len(result.notebooks) == 2
+
+    setup_notebook = result.notebooks[0]
+    assert "sftp_setup" in setup_notebook.file_path
+    assert "CREATE CONNECTION" in setup_notebook.content
+    assert "sftp.example.com" in setup_notebook.content
+
+    copy_notebook = result.notebooks[1]
+    assert "copy_data_notebooks" in copy_notebook.file_path
+
+
+def test_sftp_copy_preparer_setup_notebook_has_volume_creation() -> None:
+    """SFTP setup notebook creates an external volume."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    setup_content = result.notebooks[0].content
+    assert "CREATE EXTERNAL VOLUME" in setup_content
+    assert "sftp-server-1" in setup_content
+
+
+def test_sftp_copy_preparer_has_notebook_task() -> None:
+    """SFTP copy creates a notebook_task (not pipeline_task)."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    assert "notebook_task" in result.task
+    assert result.pipelines is None
+
+
+def test_sftp_copy_preparer_collects_secrets() -> None:
+    """SFTP copy collects SFTP credential secrets."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    assert result.secrets is not None
+    keys = {s.key for s in result.secrets}
+    assert "sftp-server-1_user_name" in keys
+    assert "sftp-server-1_password" in keys
+
+
+def test_sftp_copy_preparer_copy_notebook_uses_autoloader() -> None:
+    """SFTP copy notebook uses Auto Loader (cloudFiles) for reading."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    copy_notebook = result.notebooks[1]
+    assert "cloudFiles" in copy_notebook.content
+
+
+def test_sftp_copy_preparer_custom_credentials_scope() -> None:
+    """SFTP copy preparer respects custom credentials_scope."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(
+        activity,
+        default_files_to_delta_sinks=None,
+        credentials_scope="sftp_vault",
+    )
+
+    setup_content = result.notebooks[0].content
+    assert 'scope="sftp_vault"' in setup_content
+    assert DEFAULT_CREDENTIALS_SCOPE not in setup_content

--- a/tests/unit/test_sftp_support.py
+++ b/tests/unit/test_sftp_support.py
@@ -298,7 +298,7 @@ def test_get_sftp_options() -> None:
 
     joined = "\n".join(lines)
     assert "sftp_csv_options = {}" in joined
-    assert 'connection_name' in joined
+    assert 'cloudFiles.connectionName' in joined
     assert 'my_sftp_sftp_connection' in joined
 
 
@@ -314,7 +314,7 @@ def test_get_option_expressions_sftp_dispatches() -> None:
 
     joined = "\n".join(lines)
     assert "sftp_csv_options = {}" in joined
-    assert "connection_name" in joined
+    assert "cloudFiles.connectionName" in joined
 
 
 def test_get_sftp_read_expression() -> None:
@@ -359,8 +359,7 @@ _SFTP_SOURCE = {
     "type": "csv",
     "dataset_name": "sftp_csv_source",
     "service_name": "sftp-server-1",
-    "host": "sftp.example.com",
-    "port": 22,
+    "url": "sftp://sftp.example.com:22",
     "folder_path": "uploads/data.csv",
     "provider_type": "sftp",
     "header": "true",
@@ -469,3 +468,118 @@ def test_sftp_copy_preparer_custom_credentials_scope() -> None:
     setup_content = result.notebooks[0].content
     assert 'scope="sftp_vault"' in setup_content
     assert DEFAULT_CREDENTIALS_SCOPE not in setup_content
+
+
+def test_sftp_copy_preparer_uses_batch_read() -> None:
+    """SFTP copy notebook uses spark.read (batch), not spark.readStream."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    copy_notebook = result.notebooks[1]
+    assert "spark.read.format" in copy_notebook.content
+    assert "readStream" not in copy_notebook.content
+
+
+def test_sftp_copy_preparer_respects_files_to_delta_sinks() -> None:
+    """SFTP copy preparer threads default_files_to_delta_sinks through."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=True)
+
+    # When files_to_delta_sinks=True, should produce a pipeline task
+    assert "pipeline_task" in result.task
+    assert result.pipelines is not None
+
+
+def test_sftp_copy_preparer_setup_notebook_parses_host_from_url() -> None:
+    """Setup notebook parses host/port from the url field, not raw host/port keys."""
+    # Build a CopyActivity using a FileDataset-like source with url but no host/port keys
+    source = {
+        "type": "csv",
+        "dataset_name": "sftp_url_test",
+        "service_name": "sftp-server-url",
+        "url": "sftp://myhost.example.com:2222",
+        "folder_path": "data/files.csv",
+        "provider_type": "sftp",
+    }
+    activity = CopyActivity(
+        name="CopySftpUrlTest",
+        task_key="copysftp_url_test",
+        source_dataset=source,
+        sink_dataset=_CSV_SINK,
+        source_properties={"type": "csv"},
+        sink_properties={"type": "csv"},
+        column_mapping=[
+            ColumnMapping(
+                source_column_name="col_a",
+                sink_column_name="col_a",
+                sink_column_type="string",
+            ),
+        ],
+    )
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    setup_content = result.notebooks[0].content
+    assert "myhost.example.com" in setup_content
+    assert "2222" in setup_content
+
+
+def test_sftp_copy_end_to_end_from_file_dataset_ir() -> None:
+    """Integration: FileDataset IR -> prepare_copy_activity -> setup notebook has real host/port."""
+    from wkmigrate.parsers.dataset_parsers import merge_dataset_definition
+
+    # Simulate a FileDataset produced by _translate_sftp_file_dataset
+    sftp_dataset = FileDataset(
+        dataset_name="sftp_e2e_csv",
+        dataset_type="DelimitedText",
+        container=None,
+        folder_path="incoming/data.csv",
+        storage_account_name=None,
+        service_name="prod-sftp",
+        url="sftp://prod.sftp.example.com:2222",
+        format_options={"header": "true", "sep": ","},
+        provider_type="sftp",
+    )
+    source_properties = {"type": "csv"}
+    source_definition = merge_dataset_definition(sftp_dataset, source_properties)
+
+    # Verify url is in the merged definition and host/port are NOT
+    assert "url" in source_definition
+    assert source_definition["url"] == "sftp://prod.sftp.example.com:2222"
+    assert "host" not in source_definition
+    assert "port" not in source_definition
+
+    # Build a CopyActivity with the dataset
+    sink = {
+        "type": "csv",
+        "dataset_name": "sink_e2e",
+        "service_name": "blob_store",
+        "storage_account_name": "myacct",
+        "container": "out",
+        "folder_path": "target",
+    }
+    activity = CopyActivity(
+        name="E2eSftpCopy",
+        task_key="e2e_sftp_copy",
+        source_dataset=sftp_dataset,
+        sink_dataset=sink,
+        source_properties=source_properties,
+        sink_properties={"type": "csv"},
+        column_mapping=[
+            ColumnMapping(
+                source_column_name="id",
+                sink_column_name="id",
+                sink_column_type="int",
+            ),
+        ],
+    )
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    # Setup notebook must contain the real host and port parsed from url
+    setup_content = result.notebooks[0].content
+    assert "prod.sftp.example.com" in setup_content
+    assert "2222" in setup_content
+    assert "CREATE CONNECTION" in setup_content

--- a/tests/unit/test_sftp_support.py
+++ b/tests/unit/test_sftp_support.py
@@ -11,7 +11,7 @@ from wkmigrate.code_generator import (
     DEFAULT_CREDENTIALS_SCOPE,
     get_option_expressions,
     get_read_expression,
-    get_sftp_file_uri,
+    sftp_file_uri,
     get_sftp_options,
     get_sftp_read_expression,
     get_sftp_write_expression,
@@ -28,10 +28,6 @@ from wkmigrate.parsers.dataset_parsers import (
 from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
 from wkmigrate.translators.dataset_translators import translate_dataset, translate_file_dataset
 from wkmigrate.translators.linked_service_translators import translate_sftp_spec
-
-# ---------------------------------------------------------------------------
-# SFTP linked service translator tests
-# ---------------------------------------------------------------------------
 
 
 def test_translate_sftp_spec_full_configuration() -> None:
@@ -112,11 +108,6 @@ def test_translate_sftp_spec_generates_uuid_when_no_name() -> None:
     assert isinstance(result, SftpLinkedService)
     assert result.service_name is not None
     assert len(result.service_name) > 0
-
-
-# ---------------------------------------------------------------------------
-# SFTP dataset translator tests
-# ---------------------------------------------------------------------------
 
 
 def _build_sftp_dataset(
@@ -227,11 +218,6 @@ def test_translate_dataset_dispatches_sftp() -> None:
     assert result.provider_type == "sftp"
 
 
-# ---------------------------------------------------------------------------
-# SFTP secrets registry tests
-# ---------------------------------------------------------------------------
-
-
 def test_sftp_provider_secrets_registered() -> None:
     """SFTP provider secrets include user_name and password."""
     assert "sftp" in DATASET_PROVIDER_SECRETS
@@ -269,20 +255,16 @@ def test_collect_sftp_secrets_custom_scope() -> None:
         assert secret.scope == "custom_vault"
 
 
-# ---------------------------------------------------------------------------
-# SFTP code generator tests
-# ---------------------------------------------------------------------------
-
-
-def test_get_sftp_file_uri() -> None:
-    """get_sftp_file_uri builds a volume path."""
+def test_sftp_file_uri() -> None:
+    """sftp_file_uri builds a direct SFTP URI."""
     definition = {
         "service_name": "my_sftp",
         "folder_path": "data/incoming",
+        "url": "sftp://myhost.example.com:22",
     }
-    uri = get_sftp_file_uri(definition)
+    uri = sftp_file_uri(definition)
 
-    assert uri == "/Volumes/wkmigrate/sftp/my_sftp/data/incoming"
+    assert uri == "sftp://myhost.example.com:22/data/incoming"
 
 
 def test_get_sftp_options() -> None:
@@ -324,13 +306,14 @@ def test_get_sftp_read_expression() -> None:
         "service_name": "my_sftp",
         "folder_path": "data/incoming",
         "provider_type": "sftp",
+        "url": "sftp://myhost.example.com:22",
     }
     expr = get_sftp_read_expression(definition)
 
     assert "cloudFiles" in expr
     assert "cloudFiles.format" in expr
     assert "csv" in expr
-    assert "/Volumes/wkmigrate/sftp/my_sftp/data/incoming" in expr
+    assert "sftp://myhost.example.com:22/data/incoming" in expr
     assert "sftp_csv_df" in expr
 
 
@@ -350,18 +333,23 @@ def test_get_sftp_read_expression_uses_readstream() -> None:
 
 
 def test_get_sftp_write_expression() -> None:
-    """get_sftp_write_expression generates a streaming write with trigger(availableNow=True)."""
+    """get_sftp_write_expression generates a streaming write with format/path/start/awaitTermination."""
     expr = get_sftp_write_expression(
         dataset_name="my_sink",
-        sink_table="catalog.schema.target_table",
+        sink_format="delta",
+        sink_path="/Volumes/wkmigrate/sftp/output/data",
         checkpoint_path="/Volumes/wkmigrate/sftp/_checkpoints/my_task",
     )
 
     assert "my_sink_df.writeStream" in expr
+    assert 'format("delta")' in expr
     assert "availableNow=True" in expr
     assert "checkpointLocation" in expr
     assert "/Volumes/wkmigrate/sftp/_checkpoints/my_task" in expr
-    assert 'toTable("catalog.schema.target_table")' in expr
+    assert '"path"' in expr
+    assert ".start()" in expr
+    assert ".awaitTermination()" in expr
+    assert "toTable" not in expr
 
 
 def test_get_read_expression_sftp_dispatches() -> None:
@@ -372,17 +360,13 @@ def test_get_read_expression_sftp_dispatches() -> None:
         "service_name": "my_sftp",
         "folder_path": "uploads",
         "provider_type": "sftp",
+        "url": "sftp://my_sftp:22",
     }
     expr = get_read_expression(definition)
 
     assert "cloudFiles" in expr
     assert "sftp_csv_df" in expr
     assert "readStream" in expr
-
-
-# ---------------------------------------------------------------------------
-# SFTP copy activity preparer tests
-# ---------------------------------------------------------------------------
 
 
 _SFTP_SOURCE = {
@@ -394,6 +378,7 @@ _SFTP_SOURCE = {
     "provider_type": "sftp",
     "header": "true",
     "sep": ",",
+    "authentication_type": "Basic",
 }
 
 _CSV_SINK = {
@@ -437,20 +422,31 @@ def test_sftp_copy_preparer_produces_setup_notebook() -> None:
     assert "sftp_setup" in setup_notebook.file_path
     assert "CREATE CONNECTION" in setup_notebook.content
     assert "sftp.example.com" in setup_notebook.content
+    assert "user '{user_name}'" in setup_notebook.content
 
     copy_notebook = result.notebooks[1]
     assert "copy_data_notebooks" in copy_notebook.file_path
 
 
-def test_sftp_copy_preparer_setup_notebook_has_volume_creation() -> None:
-    """SFTP setup notebook creates an external volume."""
+def test_sftp_copy_preparer_setup_notebook_has_sink_volume_creation() -> None:
+    """SFTP setup notebook creates an external volume for the sink (non-Delta)."""
     activity = _make_sftp_copy_activity()
 
     result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
 
     setup_content = result.notebooks[0].content
     assert "CREATE EXTERNAL VOLUME" in setup_content
-    assert "sftp-server-1" in setup_content
+    assert "curated" in setup_content
+
+
+def test_sftp_copy_preparer_has_setup_task() -> None:
+    """SFTP copy produces a setup_task for the one-time setup job."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    assert result.setup_task is not None
+    assert "notebook_task" in result.setup_task
 
 
 def test_sftp_copy_preparer_has_notebook_task() -> None:
@@ -500,8 +496,18 @@ def test_sftp_copy_preparer_custom_credentials_scope() -> None:
     assert DEFAULT_CREDENTIALS_SCOPE not in setup_content
 
 
+def test_sftp_copy_preparer_setup_notebook_escapes_sql_strings() -> None:
+    """SFTP setup notebook escapes single quotes in credentials to prevent SQL injection."""
+    activity = _make_sftp_copy_activity()
+
+    result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
+
+    setup_content = result.notebooks[0].content
+    assert "replace(\"'\", \"''\")" in setup_content
+
+
 def test_sftp_copy_preparer_uses_streaming() -> None:
-    """SFTP copy notebook uses readStream + writeStream with trigger(availableNow=True)."""
+    """SFTP copy notebook uses readStream + writeStream with format/path/start/awaitTermination."""
     activity = _make_sftp_copy_activity()
 
     result = prepare_copy_activity(activity, default_files_to_delta_sinks=None)
@@ -511,6 +517,9 @@ def test_sftp_copy_preparer_uses_streaming() -> None:
     assert "writeStream" in copy_notebook.content
     assert "availableNow=True" in copy_notebook.content
     assert "checkpointLocation" in copy_notebook.content
+    assert ".start()" in copy_notebook.content
+    assert ".awaitTermination()" in copy_notebook.content
+    assert "toTable" not in copy_notebook.content
 
 
 def test_sftp_copy_preparer_respects_files_to_delta_sinks() -> None:
@@ -534,6 +543,7 @@ def test_sftp_copy_preparer_setup_notebook_parses_host_from_url() -> None:
         "url": "sftp://myhost.example.com:2222",
         "folder_path": "data/files.csv",
         "provider_type": "sftp",
+        "authentication_type": "Basic",
     }
     activity = CopyActivity(
         name="CopySftpUrlTest",


### PR DESCRIPTION
## Changes

Add support for translating ADF Copy activities that read files from SFTP servers. SFTP sources are translated to use Databricks Auto Loader with Unity Catalog connections and external volumes.

### Key changes:
- **IR model**: Added `SftpLinkedService` dataclass for SFTP connection metadata
- **Linked service translator**: New `sftp_linked_service_translator.py` with `translate_sftp_spec()`
- **Dataset translator**: Added `SftpLocation` dispatch and `_translate_sftp_file_dataset()` path for SFTP datasets (no container/bucket concept, just host + path)
- **Code generator**: Added `get_sftp_options()`, `get_sftp_read_expression()`, and `get_sftp_file_uri()` for Auto Loader-based reads from UC volumes
- **Copy activity preparer**: SFTP sources produce both a copy notebook (using `cloudFiles`/Auto Loader) and a one-time setup notebook that creates the UC connection and external volume
- **Registry**: Registered `SftpLocation` in `CLOUD_LOCATION_TYPES` and `sftp` secrets (`user_name`, `password`) in `DATASET_PROVIDER_SECRETS`

### Linked issues

Closes #57

### Tests

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests

27 new unit tests covering:
- SFTP linked service translator (full config, minimal, missing host, null input, UUID generation)
- SFTP dataset translation (CSV, Parquet, no folder, null, missing host, dispatch)
- Secrets registry (provider secrets registered, collection, custom scope)
- Code generator (file URI, options, read expression, dispatch)
- Copy activity preparer (setup notebook, volume creation, notebook task, secrets, Auto Loader, custom scope)

All 542 tests pass (515 existing + 27 new).