### PR TITLE
[FEATURE]: Support Delete activities

### DIFF
--- a/src/wkmigrate/definition_stores/workspace_definition_store.py
+++ b/src/wkmigrate/definition_stores/workspace_definition_store.py
@@ -192,6 +192,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
         inner_job_ids = self._create_inner_jobs(client, prepared.inner_workflows)
         if inner_job_ids:
             self._assign_inner_job_ids(prepared.tasks, inner_job_ids)
+        self._create_setup_jobs(client, prepared)
         job_payload = self._build_job_payload_for_api(prepared)
         response = client.jobs.create(**job_payload)
         job_id = response.job_id
@@ -753,7 +754,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
         except Exception:
             warnings.warn(f"Notebook {notebook_path} not found in target workspace", stacklevel=3)
 
-    def _write_asset_bundle(
+    def _write_asset_bundle(  # pylint: disable=too-many-locals
         self,
         prepared: PreparedWorkflow,
         bundle_dir: str,
@@ -846,7 +847,15 @@ class WorkspaceDefinitionStore(DefinitionStore):
         self._write_pipeline_resources(prepared.all_pipelines, pipelines_dir)
         self._write_secrets(prepared.all_secrets, bundle_dir)
         self._write_unsupported(prepared.pipeline.not_translatable or [], bundle_dir)
-        self._write_bundle_manifest(bundle_name, job_file, prepared.all_pipelines, bundle_dir, prepared.inner_workflows)
+        setup_job_files = self._write_setup_job_bundles(prepared, jobs_dir, notebooks_dir)
+        self._write_bundle_manifest(
+            bundle_name,
+            job_file,
+            prepared.all_pipelines,
+            bundle_dir,
+            prepared.inner_workflows,
+            setup_job_files=setup_job_files,
+        )
 
     def _write_notebooks(self, notebooks: Iterable[NotebookArtifact], output_dir: str) -> None:
         """
@@ -1029,6 +1038,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
         pipelines: Iterable[PipelineInstruction],
         bundle_dir: str,
         inner_workflows: Iterable[PreparedWorkflow] | None = None,
+        setup_job_files: list[str] | None = None,
     ) -> None:
         """
         Writes a minimal Databricks asset bundle manifest (databricks.yml).
@@ -1039,6 +1049,7 @@ class WorkspaceDefinitionStore(DefinitionStore):
             pipelines: Pipeline instructions to include.
             bundle_dir: Destination directory for the manifest.
             inner_workflows: Inner workflows whose jobs are included in the bundle.
+            setup_job_files: Relative paths to setup job YAML files to include in the bundle.
         """
         pipeline_resources = [os.path.join("resources", "pipelines", f"{pipeline.name}.yml") for pipeline in pipelines]
         job_resources = [os.path.relpath(job_file, bundle_dir)]
@@ -1046,6 +1057,8 @@ class WorkspaceDefinitionStore(DefinitionStore):
             inner_name = inner_wf.pipeline.name
             if inner_name:
                 job_resources.append(os.path.join("resources", "jobs", f"{inner_name}.yml"))
+        if setup_job_files:
+            job_resources.extend(setup_job_files)
         bundle_resources = job_resources + pipeline_resources
         manifest = {
             "bundle": {"name": bundle_name},
@@ -1333,6 +1346,76 @@ class WorkspaceDefinitionStore(DefinitionStore):
                     self._assign_inner_job_refs([nested_task])
                 elif isinstance(nested_task, list):
                     self._assign_inner_job_refs(nested_task)
+
+    def _create_setup_jobs(self, client: WorkspaceClient, prepared: PreparedWorkflow) -> None:
+        """Creates unscheduled one-time setup jobs for any setup tasks in the workflow.
+
+        Each setup task is materialized as a standalone, unscheduled job.
+        The user runs these ad-hoc before the first execution of the main workflow.
+
+        Args:
+            client: Authenticated workspace client.
+            prepared: Prepared workflow whose ``all_setup_tasks`` will be created.
+        """
+        setup_tasks = prepared.all_setup_tasks
+        if not setup_tasks:
+            return
+        for setup_activity in setup_tasks:
+            if setup_activity.notebooks:
+                self._upload_notebooks(client, setup_activity.notebooks)
+            setup_payload: dict[str, Any] = {
+                'name': f"[setup] {prepared.pipeline.name} - {setup_activity.task['task_key']}",
+                'tags': {'wkmigrate_setup': 'true'},
+                'tasks': [Task.from_dict(self._serialize_for_json(setup_activity.task))],
+            }
+            response = client.jobs.create(**setup_payload)
+            if response.job_id is None:
+                raise ValueError('Failed to create setup job')
+            logger.info(  # pylint: disable=logging-too-many-args
+                'Created setup job %s (id=%s) for pipeline %s',
+                setup_payload['name'],
+                response.job_id,
+                prepared.pipeline.name,
+            )
+
+    def _write_setup_job_bundles(
+        self,
+        prepared: PreparedWorkflow,
+        jobs_dir: str,
+        notebooks_dir: str,
+    ) -> list[str]:
+        """Writes asset bundle YAML for unscheduled setup jobs.
+
+        Each setup task is written as a separate job resource file with no schedule.
+
+        Args:
+            prepared: Prepared workflow whose ``all_setup_tasks`` will be written.
+            jobs_dir: Directory for job YAML resource files.
+            notebooks_dir: Directory for notebook source files.
+
+        Returns:
+            List of setup job resource file paths, relative to the bundle root.
+        """
+        setup_tasks = prepared.all_setup_tasks
+        if not setup_tasks:
+            return []
+        setup_job_files: list[str] = []
+        for setup_activity in setup_tasks:
+            if setup_activity.notebooks:
+                self._write_notebooks(setup_activity.notebooks, notebooks_dir)
+            task_key = setup_activity.task['task_key']
+            setup_name = f"setup_{task_key}"
+            setup_settings = {
+                'name': f"[setup] {prepared.pipeline.name} - {task_key}",
+                'tags': {'wkmigrate_setup': 'true'},
+                'tasks': [setup_activity.task],
+            }
+            setup_file = os.path.join(jobs_dir, f"{setup_name}.yml")
+            setup_resource = {'resources': {'jobs': {setup_name: self._serialize_for_json(setup_settings)}}}
+            with open(setup_file, 'w', encoding='utf-8') as setup_handle:
+                yaml.safe_dump(setup_resource, setup_handle, sort_keys=False)
+            setup_job_files.append(os.path.join('resources', 'jobs', f"{setup_name}.yml"))
+        return setup_job_files
 
     @staticmethod
     def _format_unsupported_entries(warning_entries: Iterable[dict]) -> list[dict]:

--- a/src/wkmigrate/models/ir/pipeline.py
+++ b/src/wkmigrate/models/ir/pipeline.py
@@ -220,15 +220,15 @@ class DeleteActivity(Activity):
     """
     Delete activity metadata.
 
-    Translates an ADF Delete activity into a notebook task that removes files
-    or folders from cloud storage using ``dbutils.fs.rm()``.
+    Represents an ADF Delete activity that removes files or folders from cloud
+    storage. Prepared as a notebook task using ``dbutils.fs.rm()``.
 
     Attributes:
-        dataset_name: Reference name of the dataset that identifies the storage location.
-        folder_path: Optional folder path within the dataset to delete.
-        recursive: When ``True`` the delete operation removes contents recursively.
-        wildcard_file_name: Optional wildcard pattern to match file names for deletion.
-        wildcard_folder_path: Optional wildcard pattern to match folder paths for deletion.
+        dataset_name: Reference name of the dataset identifying the storage location.
+        folder_path: Folder path within the dataset to delete, or ``None`` when unresolved.
+        recursive: When ``True`` the delete removes contents recursively.
+        wildcard_file_name: Glob pattern to filter files for deletion.
+        wildcard_folder_path: Glob pattern to filter folders for deletion.
     """
 
     dataset_name: str

--- a/src/wkmigrate/models/ir/pipeline.py
+++ b/src/wkmigrate/models/ir/pipeline.py
@@ -216,6 +216,29 @@ class WebActivity(Activity):
 
 
 @dataclass(slots=True, kw_only=True)
+class DeleteActivity(Activity):
+    """
+    Delete activity metadata.
+
+    Translates an ADF Delete activity into a notebook task that removes files
+    or folders from cloud storage using ``dbutils.fs.rm()``.
+
+    Attributes:
+        dataset_name: Reference name of the dataset that identifies the storage location.
+        folder_path: Optional folder path within the dataset to delete.
+        recursive: When ``True`` the delete operation removes contents recursively.
+        wildcard_file_name: Optional wildcard pattern to match file names for deletion.
+        wildcard_folder_path: Optional wildcard pattern to match folder paths for deletion.
+    """
+
+    dataset_name: str
+    folder_path: str | None = None
+    recursive: bool = True
+    wildcard_file_name: str | None = None
+    wildcard_folder_path: str | None = None
+
+
+@dataclass(slots=True, kw_only=True)
 class IfConditionActivity(Activity):
     """
     If Condition activity metadata.

--- a/src/wkmigrate/models/workflows/artifacts.py
+++ b/src/wkmigrate/models/workflows/artifacts.py
@@ -15,10 +15,12 @@ class PreparedWorkflow:
     Attributes:
         pipeline: Pipeline IR that this workflow was prepared from.
         activities: Prepared activities that make up this workflow's tasks.
+        setup_tasks: One-time setup tasks required before running the workflow.
     """
 
     pipeline: Pipeline
     activities: list[PreparedActivity]
+    setup_tasks: list[PreparedActivity] | None = None
 
     @property
     def tasks(self) -> list[dict[str, Any]]:
@@ -68,6 +70,19 @@ class PreparedWorkflow:
                 result.extend(activity.inner_workflow.inner_workflows)
         return result
 
+    @property
+    def all_setup_tasks(self) -> list["PreparedActivity"]:
+        """All setup tasks across this workflow and any nested inner workflows."""
+        result: list[PreparedActivity] = []
+        if self.setup_tasks:
+            result.extend(self.setup_tasks)
+        for activity in self.activities:
+            if activity.setup_tasks:
+                result.extend(activity.setup_tasks)
+            if activity.inner_workflow:
+                result.extend(activity.inner_workflow.all_setup_tasks)
+        return result
+
 
 @dataclass(slots=True)
 class PreparedActivity:
@@ -80,6 +95,7 @@ class PreparedActivity:
         pipelines: List of ``PipelineInstruction`` objects describing DLT pipelines to create.
         secrets: List of ``SecretInstruction`` objects describing secrets to materialize.
         inner_workflow: Additional workflow settings created for nested ForEach tasks.
+        setup_tasks: One-time setup tasks that must run before this activity can execute.
     """
 
     task: dict[str, Any]
@@ -87,6 +103,7 @@ class PreparedActivity:
     pipelines: list[PipelineInstruction] | None = None
     secrets: list[SecretInstruction] | None = None
     inner_workflow: "PreparedWorkflow" | None = None
+    setup_tasks: list["PreparedActivity"] | None = None
 
 
 @dataclass(slots=True)

--- a/src/wkmigrate/models/workflows/artifacts.py
+++ b/src/wkmigrate/models/workflows/artifacts.py
@@ -72,13 +72,16 @@ class PreparedWorkflow:
 
     @property
     def all_setup_tasks(self) -> list["PreparedActivity"]:
-        """All setup tasks across this workflow and any nested inner workflows."""
+        """All setup tasks across this workflow and any nested inner workflows.
+
+        Setup tasks from individual activities are hoisted into
+        ``self.setup_tasks`` by ``prepare_workflow``, so we only need to
+        collect from there and recurse into inner workflows.
+        """
         result: list[PreparedActivity] = []
         if self.setup_tasks:
             result.extend(self.setup_tasks)
         for activity in self.activities:
-            if activity.setup_tasks:
-                result.extend(activity.setup_tasks)
             if activity.inner_workflow:
                 result.extend(activity.inner_workflow.all_setup_tasks)
         return result

--- a/src/wkmigrate/preparers/delete_activity_preparer.py
+++ b/src/wkmigrate/preparers/delete_activity_preparer.py
@@ -1,7 +1,10 @@
 """Preparer for Delete activities.
 
 Builds a Databricks notebook task that removes files or folders from cloud
-storage using ``dbutils.fs.rm()``.
+storage using ``dbutils.fs.rm()``.  When a folder path can be resolved the
+preparer also emits a one-time setup task that creates a Unity Catalog
+external volume, giving the delete notebook an easily-accessible
+``/Volumes/<catalog>/<schema>/<volume>`` path.
 """
 
 from __future__ import annotations
@@ -16,15 +19,28 @@ from wkmigrate.not_translatable import NotTranslatableWarning
 from wkmigrate.preparers.utils import get_base_task
 from wkmigrate.utils import parse_mapping
 
+# Default UC coordinates used when no catalog/schema is provided.
+_DEFAULT_CATALOG = 'main'
+_DEFAULT_SCHEMA = 'default'
 
-def prepare_delete_activity(activity: DeleteActivity) -> PreparedActivity:
+
+def prepare_delete_activity(
+    activity: DeleteActivity,
+    *,
+    catalog: str | None = None,
+    schema: str | None = None,
+) -> PreparedActivity:
     """Builds the task payload for a Delete activity.
 
     The resulting notebook removes files or folders from cloud storage
-    using ``dbutils.fs.rm()``.
+    using ``dbutils.fs.rm()``.  A one-time setup task is attached when
+    the folder path is available so that a Unity Catalog external volume
+    can be created prior to the first run.
 
     Args:
         activity: Activity definition emitted by the translators.
+        catalog: Unity Catalog catalog for the external volume. Falls back to ``'main'``.
+        schema: Unity Catalog schema for the external volume. Falls back to ``'default'``.
 
     Returns:
         PreparedActivity containing the notebook task configuration and artifacts.
@@ -34,7 +50,8 @@ def prepare_delete_activity(activity: DeleteActivity) -> PreparedActivity:
     notebook = NotebookArtifact(file_path=notebook_path, content=notebook_content)
     base_task = get_base_task(activity)
     task = parse_mapping({**base_task, "notebook_task": {"notebook_path": notebook_path}})
-    return PreparedActivity(task=task, notebooks=[notebook])
+    setup_tasks = _build_setup_tasks(activity, catalog=catalog, schema=schema)
+    return PreparedActivity(task=task, notebooks=[notebook], setup_tasks=setup_tasks or None)
 
 
 def _build_notebook_content(activity: DeleteActivity) -> str:
@@ -134,3 +151,91 @@ def _append_delete_logic(
         )
     else:
         lines.append(f"dbutils.fs.rm(path, recurse={recursive})")
+
+
+def _build_setup_tasks(
+    activity: DeleteActivity,
+    *,
+    catalog: str | None = None,
+    schema: str | None = None,
+) -> list[PreparedActivity]:
+    """Builds a one-time setup task that creates a UC external volume for the delete target.
+
+    The external volume provides a ``/Volumes/<catalog>/<schema>/<volume>``
+    path that maps to the cloud storage location used by the delete notebook.
+
+    Args:
+        activity: Fully populated ``DeleteActivity`` IR object.
+        catalog: Unity Catalog catalog name. Falls back to ``_DEFAULT_CATALOG``.
+        schema: Unity Catalog schema name. Falls back to ``_DEFAULT_SCHEMA``.
+
+    Returns:
+        List containing a single ``PreparedActivity`` for the setup notebook,
+        or an empty list when the folder path cannot be resolved.
+    """
+    if not activity.folder_path:
+        return []
+
+    effective_catalog = catalog or _DEFAULT_CATALOG
+    effective_schema = schema or _DEFAULT_SCHEMA
+    volume_name = f"wkmigrate_{activity.task_key}"
+    notebook_content = _build_volume_notebook_content(
+        catalog=effective_catalog,
+        schema=effective_schema,
+        volume_name=volume_name,
+        storage_location=activity.folder_path,
+    )
+    notebook_path = f"/wkmigrate/setup_notebooks/create_volume_{activity.task_key}"
+    notebook = NotebookArtifact(file_path=notebook_path, content=notebook_content, language='python')
+    task = parse_mapping(
+        {
+            "task_key": f"setup_volume_{activity.task_key}",
+            "description": f"One-time setup: create external volume for delete activity '{activity.name}'.",
+            "notebook_task": {"notebook_path": notebook_path},
+        }
+    )
+    return [PreparedActivity(task=task, notebooks=[notebook])]
+
+
+def _build_volume_notebook_content(
+    *,
+    catalog: str,
+    schema: str,
+    volume_name: str,
+    storage_location: str,
+) -> str:
+    """Generates a Python notebook that creates a Unity Catalog external volume.
+
+    The notebook executes ``CREATE EXTERNAL VOLUME IF NOT EXISTS`` so it is
+    safe to run repeatedly.
+
+    Args:
+        catalog: Unity Catalog catalog name.
+        schema: Unity Catalog schema name.
+        volume_name: Volume name to create.
+        storage_location: Cloud storage URL that the volume will point to.
+
+    Returns:
+        Formatted Python notebook source.
+    """
+    lines: list[str] = [
+        '# Databricks notebook source',
+        '',
+        '# Setup: create external volume for delete activity',
+        f'# Volume path: /Volumes/{catalog}/{schema}/{volume_name}',
+        '',
+        f'catalog = {catalog!r}',
+        f'schema = {schema!r}',
+        f'volume_name = {volume_name!r}',
+        f'storage_location = {storage_location!r}',
+        '',
+        'spark.sql(f"""',
+        '    CREATE EXTERNAL VOLUME IF NOT EXISTS',
+        '    `{catalog}`.`{schema}`.`{volume_name}`',
+        "    LOCATION '{storage_location}'",
+        "    COMMENT 'External volume created by wkmigrate for delete activity.'",
+        '""")',
+        '',
+        'print(f"Volume /Volumes/{catalog}/{schema}/{volume_name} is ready.")',
+    ]
+    return autopep8.fix_code('\n'.join(lines))

--- a/src/wkmigrate/preparers/delete_activity_preparer.py
+++ b/src/wkmigrate/preparers/delete_activity_preparer.py
@@ -1,7 +1,7 @@
-"""This module defines a preparer for Delete activities.
+"""Preparer for Delete activities.
 
-The preparer builds a Databricks notebook task that removes files or folders
-from cloud storage using ``dbutils.fs.rm()``.
+Builds a Databricks notebook task that removes files or folders from cloud
+storage using ``dbutils.fs.rm()``.
 """
 
 from __future__ import annotations
@@ -29,14 +29,7 @@ def prepare_delete_activity(activity: DeleteActivity) -> PreparedActivity:
     Returns:
         PreparedActivity containing the notebook task configuration and artifacts.
     """
-    notebook_content = _get_delete_activity_notebook_content(
-        activity_name=activity.name,
-        dataset_name=activity.dataset_name,
-        folder_path=activity.folder_path,
-        recursive=activity.recursive,
-        wildcard_file_name=activity.wildcard_file_name,
-        wildcard_folder_path=activity.wildcard_folder_path,
-    )
+    notebook_content = _build_notebook_content(activity)
     notebook_path = f"/wkmigrate/delete_activity_notebooks/{activity.task_key}"
     notebook = NotebookArtifact(file_path=notebook_path, content=notebook_content)
     base_task = get_base_task(activity)
@@ -44,36 +37,40 @@ def prepare_delete_activity(activity: DeleteActivity) -> PreparedActivity:
     return PreparedActivity(task=task, notebooks=[notebook])
 
 
-def _get_delete_activity_notebook_content(
-    activity_name: str,
-    dataset_name: str,
-    folder_path: str | None,
-    recursive: bool,
-    wildcard_file_name: str | None,
-    wildcard_folder_path: str | None,
-) -> str:
-    """Generates notebook source for a Delete activity.
+def _build_notebook_content(activity: DeleteActivity) -> str:
+    """Generates formatted Python notebook source for a Delete activity.
+
+    Produces a self-contained Databricks notebook that deletes files or folders
+    via ``dbutils.fs.rm()``. When wildcard patterns are present the notebook
+    lists directory contents and filters with ``fnmatch``.
 
     Args:
-        activity_name: Logical name of the activity being translated.
-        dataset_name: Reference name of the dataset that identifies the storage location.
-        folder_path: Optional folder path within the dataset to delete.
-        recursive: When ``True`` the delete operation removes contents recursively.
-        wildcard_file_name: Optional wildcard pattern to match file names for deletion.
-        wildcard_folder_path: Optional wildcard pattern to match folder paths for deletion.
+        activity: Fully populated ``DeleteActivity`` IR object.
 
     Returns:
-        Formatted Python notebook source as a ``str``.
+        Formatted Python notebook source.
     """
-    script_lines = [
+    lines: list[str] = [
         "# Databricks notebook source",
         "",
-        f"# Delete activity: {activity_name}",
-        f"# Dataset: {dataset_name}",
+        f"# Delete activity: {activity.name}",
+        f"# Dataset: {activity.dataset_name}",
     ]
 
+    _append_path_assignment(lines, activity.dataset_name, activity.folder_path)
+    _append_delete_logic(lines, activity.recursive, activity.wildcard_file_name, activity.wildcard_folder_path)
+
+    return autopep8.fix_code("\n".join(lines))
+
+
+def _append_path_assignment(lines: list[str], dataset_name: str, folder_path: str | None) -> None:
+    """Appends the ``path`` variable assignment to notebook lines.
+
+    Emits a ``NotTranslatableWarning`` and a TODO placeholder when the
+    folder path cannot be resolved from the dataset reference.
+    """
     if folder_path:
-        script_lines.append(f"path = {folder_path!r}")
+        lines.append(f"path = {folder_path!r}")
     else:
         warnings.warn(
             NotTranslatableWarning(
@@ -83,12 +80,23 @@ def _get_delete_activity_notebook_content(
             ),
             stacklevel=2,
         )
-        script_lines.append(f"# TODO: Resolve storage path for dataset '{dataset_name}'")
-        script_lines.append(f"path = '<UNRESOLVED_PATH_FOR_{dataset_name}>'")
+        lines.append(f"# TODO: Resolve storage path for dataset '{dataset_name}'")
+        lines.append(f"path = '<UNRESOLVED_PATH_FOR_{dataset_name}>'")
 
+
+def _append_delete_logic(
+    lines: list[str],
+    recursive: bool,
+    wildcard_file_name: str | None,
+    wildcard_folder_path: str | None,
+) -> None:
+    """Appends the ``dbutils.fs.rm`` call(s) to notebook lines.
+
+    Chooses the appropriate deletion strategy based on which wildcard
+    patterns are set: two-level, file-only, folder-only, or direct.
+    """
     if wildcard_folder_path and wildcard_file_name:
-        # Two-level listing: filter folders by wildcard_folder_path, then files by wildcard_file_name.
-        script_lines.extend(
+        lines.extend(
             [
                 "import fnmatch",
                 f"wildcard_folder_path = {wildcard_folder_path!r}",
@@ -103,8 +111,7 @@ def _get_delete_activity_notebook_content(
             ]
         )
     elif wildcard_file_name:
-        # Single-level listing: filter files at path by wildcard_file_name.
-        script_lines.extend(
+        lines.extend(
             [
                 "import fnmatch",
                 f"wildcard_file_name = {wildcard_file_name!r}",
@@ -115,8 +122,7 @@ def _get_delete_activity_notebook_content(
             ]
         )
     elif wildcard_folder_path:
-        # Folder-only wildcard: filter folders at path by wildcard_folder_path and delete each match.
-        script_lines.extend(
+        lines.extend(
             [
                 "import fnmatch",
                 f"wildcard_folder_path = {wildcard_folder_path!r}",
@@ -127,6 +133,4 @@ def _get_delete_activity_notebook_content(
             ]
         )
     else:
-        script_lines.append(f"dbutils.fs.rm(path, recurse={recursive})")
-
-    return autopep8.fix_code("\n".join(script_lines))
+        lines.append(f"dbutils.fs.rm(path, recurse={recursive})")

--- a/src/wkmigrate/preparers/delete_activity_preparer.py
+++ b/src/wkmigrate/preparers/delete_activity_preparer.py
@@ -24,6 +24,11 @@ _DEFAULT_CATALOG = 'main'
 _DEFAULT_SCHEMA = 'default'
 
 
+def _strip_newlines(value: str) -> str:
+    """Replace CR/LF characters with spaces so *value* is safe for a single-line notebook comment."""
+    return value.replace('\n', ' ').replace('\r', ' ')
+
+
 def prepare_delete_activity(
     activity: DeleteActivity,
     *,
@@ -70,8 +75,8 @@ def _build_notebook_content(activity: DeleteActivity) -> str:
     lines: list[str] = [
         "# Databricks notebook source",
         "",
-        f"# Delete activity: {activity.name.replace(chr(10), ' ').replace(chr(13), ' ')}",
-        f"# Dataset: {activity.dataset_name.replace(chr(10), ' ').replace(chr(13), ' ')}",
+        f"# Delete activity: {_strip_newlines(activity.name)}",
+        f"# Dataset: {_strip_newlines(activity.dataset_name)}",
     ]
 
     _append_path_assignment(lines, activity.dataset_name, activity.folder_path)
@@ -85,6 +90,11 @@ def _append_path_assignment(lines: list[str], dataset_name: str, folder_path: st
 
     Emits a ``NotTranslatableWarning`` and a TODO placeholder when the
     folder path cannot be resolved from the dataset reference.
+
+    Args:
+        lines: Mutable list of notebook source lines to extend.
+        dataset_name: Reference name of the dataset (used in the placeholder).
+        folder_path: Resolved storage path, or ``None`` when unresolved.
     """
     if folder_path:
         lines.append(f"path = {folder_path!r}")
@@ -111,6 +121,12 @@ def _append_delete_logic(
 
     Chooses the appropriate deletion strategy based on which wildcard
     patterns are set: two-level, file-only, folder-only, or direct.
+
+    Args:
+        lines: Mutable list of notebook source lines to extend.
+        recursive: Whether deletes should recurse into sub-directories.
+        wildcard_file_name: Glob pattern to filter files, or ``None``.
+        wildcard_folder_path: Glob pattern to filter folders, or ``None``.
     """
     if wildcard_folder_path and wildcard_file_name:
         lines.extend(
@@ -232,7 +248,7 @@ def _build_volume_notebook_content(
         'spark.sql(f"""',
         '    CREATE EXTERNAL VOLUME IF NOT EXISTS',
         '    `{catalog}`.`{schema}`.`{volume_name}`',
-        "    LOCATION '{storage_location.replace(chr(39), chr(39)*2)}'",
+        "    LOCATION '{storage_location.replace(chr(39), chr(39)*2)}'",  # escape single quotes for SQL
         "    COMMENT 'External volume created by wkmigrate for delete activity.'",
         '""")',
         '',

--- a/src/wkmigrate/preparers/delete_activity_preparer.py
+++ b/src/wkmigrate/preparers/delete_activity_preparer.py
@@ -6,10 +6,13 @@ from cloud storage using ``dbutils.fs.rm()``.
 
 from __future__ import annotations
 
+import warnings
+
 import autopep8  # type: ignore
 
 from wkmigrate.models.ir.pipeline import DeleteActivity
 from wkmigrate.models.workflows.artifacts import NotebookArtifact, PreparedActivity
+from wkmigrate.not_translatable import NotTranslatableWarning
 from wkmigrate.preparers.utils import get_base_task
 from wkmigrate.utils import parse_mapping
 
@@ -62,31 +65,65 @@ def _get_delete_activity_notebook_content(
     Returns:
         Formatted Python notebook source as a ``str``.
     """
-    path = folder_path or dataset_name
-
     script_lines = [
         "# Databricks notebook source",
         "",
         f"# Delete activity: {activity_name}",
         f"# Dataset: {dataset_name}",
-        f"path = {path!r}",
     ]
 
-    if wildcard_file_name:
-        script_lines.append(f"wildcard_file_name = {wildcard_file_name!r}")
-        script_lines.append("# NOTE: Wildcard deletion requires listing and filtering files manually.")
-        script_lines.append("import fnmatch")
-        if wildcard_folder_path:
-            script_lines.append(f"wildcard_folder_path = {wildcard_folder_path!r}")
-            script_lines.append(
-                "# Filter folders matching the wildcard folder path, then files matching the wildcard file name."
-            )
+    if folder_path:
+        script_lines.append(f"path = {folder_path!r}")
+    else:
+        warnings.warn(
+            NotTranslatableWarning(
+                "folder_path",
+                f"Storage path could not be resolved from dataset reference '{dataset_name}'. "
+                "Replace the placeholder path below with the actual storage location.",
+            ),
+            stacklevel=2,
+        )
+        script_lines.append(f"# TODO: Resolve storage path for dataset '{dataset_name}'")
+        script_lines.append(f"path = '<UNRESOLVED_PATH_FOR_{dataset_name}>'")
+
+    if wildcard_folder_path and wildcard_file_name:
+        # Two-level listing: filter folders by wildcard_folder_path, then files by wildcard_file_name.
         script_lines.extend(
             [
+                "import fnmatch",
+                f"wildcard_folder_path = {wildcard_folder_path!r}",
+                f"wildcard_file_name = {wildcard_file_name!r}",
+                "folders = dbutils.fs.ls(path)",
+                "for folder in folders:",
+                "    if fnmatch.fnmatch(folder.name, wildcard_folder_path):",
+                "        files = dbutils.fs.ls(folder.path)",
+                "        for f in files:",
+                "            if fnmatch.fnmatch(f.name, wildcard_file_name):",
+                f"                dbutils.fs.rm(f.path, recurse={recursive})",
+            ]
+        )
+    elif wildcard_file_name:
+        # Single-level listing: filter files at path by wildcard_file_name.
+        script_lines.extend(
+            [
+                "import fnmatch",
+                f"wildcard_file_name = {wildcard_file_name!r}",
                 "files = dbutils.fs.ls(path)",
                 "for f in files:",
                 "    if fnmatch.fnmatch(f.name, wildcard_file_name):",
                 f"        dbutils.fs.rm(f.path, recurse={recursive})",
+            ]
+        )
+    elif wildcard_folder_path:
+        # Folder-only wildcard: filter folders at path by wildcard_folder_path and delete each match.
+        script_lines.extend(
+            [
+                "import fnmatch",
+                f"wildcard_folder_path = {wildcard_folder_path!r}",
+                "folders = dbutils.fs.ls(path)",
+                "for folder in folders:",
+                "    if fnmatch.fnmatch(folder.name, wildcard_folder_path):",
+                f"        dbutils.fs.rm(folder.path, recurse={recursive})",
             ]
         )
     else:

--- a/src/wkmigrate/preparers/delete_activity_preparer.py
+++ b/src/wkmigrate/preparers/delete_activity_preparer.py
@@ -1,0 +1,95 @@
+"""This module defines a preparer for Delete activities.
+
+The preparer builds a Databricks notebook task that removes files or folders
+from cloud storage using ``dbutils.fs.rm()``.
+"""
+
+from __future__ import annotations
+
+import autopep8  # type: ignore
+
+from wkmigrate.models.ir.pipeline import DeleteActivity
+from wkmigrate.models.workflows.artifacts import NotebookArtifact, PreparedActivity
+from wkmigrate.preparers.utils import get_base_task
+from wkmigrate.utils import parse_mapping
+
+
+def prepare_delete_activity(activity: DeleteActivity) -> PreparedActivity:
+    """Builds the task payload for a Delete activity.
+
+    The resulting notebook removes files or folders from cloud storage
+    using ``dbutils.fs.rm()``.
+
+    Args:
+        activity: Activity definition emitted by the translators.
+
+    Returns:
+        PreparedActivity containing the notebook task configuration and artifacts.
+    """
+    notebook_content = _get_delete_activity_notebook_content(
+        activity_name=activity.name,
+        dataset_name=activity.dataset_name,
+        folder_path=activity.folder_path,
+        recursive=activity.recursive,
+        wildcard_file_name=activity.wildcard_file_name,
+        wildcard_folder_path=activity.wildcard_folder_path,
+    )
+    notebook_path = f"/wkmigrate/delete_activity_notebooks/{activity.task_key}"
+    notebook = NotebookArtifact(file_path=notebook_path, content=notebook_content)
+    base_task = get_base_task(activity)
+    task = parse_mapping({**base_task, "notebook_task": {"notebook_path": notebook_path}})
+    return PreparedActivity(task=task, notebooks=[notebook])
+
+
+def _get_delete_activity_notebook_content(
+    activity_name: str,
+    dataset_name: str,
+    folder_path: str | None,
+    recursive: bool,
+    wildcard_file_name: str | None,
+    wildcard_folder_path: str | None,
+) -> str:
+    """Generates notebook source for a Delete activity.
+
+    Args:
+        activity_name: Logical name of the activity being translated.
+        dataset_name: Reference name of the dataset that identifies the storage location.
+        folder_path: Optional folder path within the dataset to delete.
+        recursive: When ``True`` the delete operation removes contents recursively.
+        wildcard_file_name: Optional wildcard pattern to match file names for deletion.
+        wildcard_folder_path: Optional wildcard pattern to match folder paths for deletion.
+
+    Returns:
+        Formatted Python notebook source as a ``str``.
+    """
+    path = folder_path or dataset_name
+
+    script_lines = [
+        "# Databricks notebook source",
+        "",
+        f"# Delete activity: {activity_name}",
+        f"# Dataset: {dataset_name}",
+        f"path = {path!r}",
+    ]
+
+    if wildcard_file_name:
+        script_lines.append(f"wildcard_file_name = {wildcard_file_name!r}")
+        script_lines.append("# NOTE: Wildcard deletion requires listing and filtering files manually.")
+        script_lines.append("import fnmatch")
+        if wildcard_folder_path:
+            script_lines.append(f"wildcard_folder_path = {wildcard_folder_path!r}")
+            script_lines.append(
+                "# Filter folders matching the wildcard folder path, then files matching the wildcard file name."
+            )
+        script_lines.extend(
+            [
+                "files = dbutils.fs.ls(path)",
+                "for f in files:",
+                "    if fnmatch.fnmatch(f.name, wildcard_file_name):",
+                f"        dbutils.fs.rm(f.path, recurse={recursive})",
+            ]
+        )
+    else:
+        script_lines.append(f"dbutils.fs.rm(path, recurse={recursive})")
+
+    return autopep8.fix_code("\n".join(script_lines))

--- a/src/wkmigrate/preparers/delete_activity_preparer.py
+++ b/src/wkmigrate/preparers/delete_activity_preparer.py
@@ -70,8 +70,8 @@ def _build_notebook_content(activity: DeleteActivity) -> str:
     lines: list[str] = [
         "# Databricks notebook source",
         "",
-        f"# Delete activity: {activity.name}",
-        f"# Dataset: {activity.dataset_name}",
+        f"# Delete activity: {activity.name.replace(chr(10), ' ').replace(chr(13), ' ')}",
+        f"# Dataset: {activity.dataset_name.replace(chr(10), ' ').replace(chr(13), ' ')}",
     ]
 
     _append_path_assignment(lines, activity.dataset_name, activity.folder_path)
@@ -97,8 +97,8 @@ def _append_path_assignment(lines: list[str], dataset_name: str, folder_path: st
             ),
             stacklevel=2,
         )
-        lines.append(f"# TODO: Resolve storage path for dataset '{dataset_name}'")
-        lines.append(f"path = '<UNRESOLVED_PATH_FOR_{dataset_name}>'")
+        lines.append(f"# TODO: Resolve storage path for dataset {dataset_name!r}")
+        lines.append(f"path = '<UNRESOLVED_PATH_FOR_' + {dataset_name!r} + '>'")
 
 
 def _append_delete_logic(
@@ -232,7 +232,7 @@ def _build_volume_notebook_content(
         'spark.sql(f"""',
         '    CREATE EXTERNAL VOLUME IF NOT EXISTS',
         '    `{catalog}`.`{schema}`.`{volume_name}`',
-        "    LOCATION '{storage_location}'",
+        "    LOCATION '{storage_location.replace(chr(39), chr(39)*2)}'",
         "    COMMENT 'External volume created by wkmigrate for delete activity.'",
         '""")',
         '',

--- a/src/wkmigrate/preparers/preparer.py
+++ b/src/wkmigrate/preparers/preparer.py
@@ -56,7 +56,11 @@ def prepare_workflow(
         Prepared workflow containing the Databricks job payload and supporting artifacts for the pipeline.
     """
     activities = [prepare_activity(task, files_to_delta_sinks, credentials_scope) for task in pipeline.tasks]
-    return PreparedWorkflow(pipeline=pipeline, activities=activities)
+    setup_tasks: list[PreparedActivity] = []
+    for activity in activities:
+        if activity.setup_tasks:
+            setup_tasks.extend(activity.setup_tasks)
+    return PreparedWorkflow(pipeline=pipeline, activities=activities, setup_tasks=setup_tasks or None)
 
 
 def prepare_activity(

--- a/src/wkmigrate/preparers/preparer.py
+++ b/src/wkmigrate/preparers/preparer.py
@@ -14,6 +14,7 @@ from wkmigrate.models.ir.pipeline import (
     Activity,
     CopyActivity,
     DatabricksNotebookActivity,
+    DeleteActivity,
     ForEachActivity,
     IfConditionActivity,
     LookupActivity,
@@ -26,6 +27,7 @@ from wkmigrate.models.ir.pipeline import (
 )
 from wkmigrate.models.workflows.artifacts import PreparedActivity, PreparedWorkflow
 from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
+from wkmigrate.preparers.delete_activity_preparer import prepare_delete_activity
 from wkmigrate.preparers.for_each_activity_preparer import prepare_for_each_activity
 from wkmigrate.preparers.if_condition_activity_preparer import prepare_if_condition_activity
 from wkmigrate.preparers.lookup_activity_preparer import prepare_lookup_activity
@@ -87,6 +89,8 @@ def prepare_activity(
         return prepare_run_job_activity(activity, default_files_to_delta_sinks, credentials_scope)
     if isinstance(activity, CopyActivity):
         return prepare_copy_activity(activity, default_files_to_delta_sinks, credentials_scope)
+    if isinstance(activity, DeleteActivity):
+        return prepare_delete_activity(activity)
     if isinstance(activity, LookupActivity):
         return prepare_lookup_activity(activity, credentials_scope)
     if isinstance(activity, WebActivity):

--- a/src/wkmigrate/translators/activity_translators/activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/activity_translator.py
@@ -26,6 +26,7 @@ from wkmigrate.translators.activity_translators.copy_activity_translator import 
 from wkmigrate.translators.activity_translators.databricks_job_activity_translator import (
     translate_databricks_job_activity,
 )
+from wkmigrate.translators.activity_translators.delete_activity_translator import translate_delete_activity
 from wkmigrate.translators.activity_translators.for_each_activity_translator import translate_for_each_activity
 from wkmigrate.translators.activity_translators.if_condition_activity_translator import translate_if_condition_activity
 from wkmigrate.translators.activity_translators.lookup_activity_translator import translate_lookup_activity
@@ -45,6 +46,7 @@ _default_type_translators: dict[str, TypeTranslator] = {
     "DatabricksSparkJar": translate_spark_jar_activity,
     "DatabricksSparkPython": translate_spark_python_activity,
     "Copy": translate_copy_activity,
+    "Delete": translate_delete_activity,
     "Lookup": translate_lookup_activity,
     "WebActivity": translate_web_activity,
 }

--- a/src/wkmigrate/translators/activity_translators/delete_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/delete_activity_translator.py
@@ -1,10 +1,8 @@
-"""This module defines a translator for translating Delete activities.
+"""Translator for ADF Delete activities.
 
-Translators in this module normalize ADF Delete activity payloads into internal
-representations. The Delete activity removes files or folders from supported
-storage stores.  Each translator must validate required fields, parse the
-dataset reference and store settings, and emit ``NotTranslatableWarning``
-objects for any features that cannot be migrated.
+Normalizes ADF Delete activity payloads into ``DeleteActivity`` IR objects.
+Validates required fields (dataset reference, store settings) and emits
+``NotTranslatableWarning`` for unsupported features like delete logging.
 """
 
 import warnings
@@ -15,14 +13,19 @@ from wkmigrate.not_translatable import NotTranslatableWarning
 
 
 def translate_delete_activity(activity: dict, base_kwargs: dict) -> DeleteActivity | UnsupportedValue:
-    """Translates an ADF Delete activity into a ``DeleteActivity`` object.
+    """Translates an ADF Delete activity into a ``DeleteActivity`` IR object.
+
+    Validates the dataset reference and extracts store settings (wildcard
+    patterns, folder path). Emits warnings for unsupported ADF features
+    like ``enableLogging`` and ``logStorageSettings``.
 
     Args:
-        activity: Delete activity definition as a ``dict``.
-        base_kwargs: Common activity metadata.
+        activity: Raw ADF Delete activity payload.
+        base_kwargs: Common activity metadata produced by the dispatcher.
 
     Returns:
-        ``DeleteActivity`` representation of the delete task.
+        ``DeleteActivity`` on success, or ``UnsupportedValue`` when required
+        fields are missing.
     """
     dataset_ref = activity.get("dataset")
     if not isinstance(dataset_ref, dict):

--- a/src/wkmigrate/translators/activity_translators/delete_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/delete_activity_translator.py
@@ -1,0 +1,68 @@
+"""This module defines a translator for translating Delete activities.
+
+Translators in this module normalize ADF Delete activity payloads into internal
+representations. The Delete activity removes files or folders from supported
+storage stores.  Each translator must validate required fields, parse the
+dataset reference and store settings, and emit ``NotTranslatableWarning``
+objects for any features that cannot be migrated.
+"""
+
+import warnings
+
+from wkmigrate.models.ir.pipeline import DeleteActivity
+from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.not_translatable import NotTranslatableWarning
+
+
+def translate_delete_activity(activity: dict, base_kwargs: dict) -> DeleteActivity | UnsupportedValue:
+    """Translates an ADF Delete activity into a ``DeleteActivity`` object.
+
+    Args:
+        activity: Delete activity definition as a ``dict``.
+        base_kwargs: Common activity metadata.
+
+    Returns:
+        ``DeleteActivity`` representation of the delete task.
+    """
+    dataset_ref = activity.get("dataset")
+    if not isinstance(dataset_ref, dict):
+        return UnsupportedValue(activity, "Missing value 'dataset' for Delete activity")
+
+    dataset_name = dataset_ref.get("reference_name")
+    if not dataset_name:
+        return UnsupportedValue(activity, "Missing value 'dataset.referenceName' for Delete activity")
+
+    recursive = activity.get("recursive", True)
+
+    store_settings = activity.get("store_settings") or {}
+    wildcard_file_name = store_settings.get("wildcard_file_name")
+    wildcard_folder_path = store_settings.get("wildcard_folder_path")
+
+    folder_path = activity.get("folder_path")
+
+    if activity.get("enable_logging"):
+        warnings.warn(
+            NotTranslatableWarning(
+                "enableLogging",
+                "Delete activity logging is not supported in Databricks workflows.",
+            ),
+            stacklevel=2,
+        )
+
+    if activity.get("log_storage_settings"):
+        warnings.warn(
+            NotTranslatableWarning(
+                "logStorageSettings",
+                "Delete activity log storage settings are not supported in Databricks workflows.",
+            ),
+            stacklevel=2,
+        )
+
+    return DeleteActivity(
+        **base_kwargs,
+        dataset_name=dataset_name,
+        folder_path=folder_path,
+        recursive=bool(recursive),
+        wildcard_file_name=wildcard_file_name,
+        wildcard_folder_path=wildcard_folder_path,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,12 @@ def linked_service_fixtures() -> list[dict]:
 
 
 @pytest.fixture
+def delete_activity_fixtures() -> list[dict]:
+    """Load Delete activity test fixtures."""
+    return load_fixtures("delete_activities.json")
+
+
+@pytest.fixture
 def web_activity_fixtures() -> list[dict]:
     """Load Web activity test fixtures."""
     return load_fixtures("web_activities.json")

--- a/tests/resources/activities/delete_activities.json
+++ b/tests/resources/activities/delete_activities.json
@@ -135,6 +135,32 @@
     }
   },
   {
+    "id": "delete_with_wildcard_folder_only",
+    "description": "Delete activity - wildcard folder path without wildcard file name",
+    "input": {
+      "name": "delete_old_folders",
+      "type": "Delete",
+      "description": "Remove folders matching a wildcard pattern",
+      "depends_on": [],
+      "dataset": {
+        "reference_name": "ArchiveDataset",
+        "type": "DatasetReference"
+      },
+      "recursive": true,
+      "store_settings": {
+        "type": "AzureBlobFSReadSettings",
+        "wildcard_folder_path": "archive/2023-*"
+      }
+    },
+    "expected": {
+      "name": "delete_old_folders",
+      "task_key": "delete_old_folders",
+      "dataset_name": "ArchiveDataset",
+      "recursive": true,
+      "wildcard_folder_path": "archive/2023-*"
+    }
+  },
+  {
     "id": "missing_dataset",
     "description": "Delete activity - missing dataset returns UnsupportedValue",
     "input": {

--- a/tests/resources/activities/delete_activities.json
+++ b/tests/resources/activities/delete_activities.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "basic_delete",
+    "description": "Delete activity - simple recursive delete",
+    "input": {
+      "name": "delete_staging_files",
+      "type": "Delete",
+      "description": "Remove staging files after processing",
+      "depends_on": [],
+      "policy": {
+        "timeout": "0.01:00:00",
+        "retry": 2,
+        "retry_interval_in_seconds": 30
+      },
+      "dataset": {
+        "reference_name": "StagingDataset",
+        "type": "DatasetReference"
+      },
+      "recursive": true
+    },
+    "expected": {
+      "name": "delete_staging_files",
+      "task_key": "delete_staging_files",
+      "dataset_name": "StagingDataset",
+      "recursive": true,
+      "timeout_seconds": 3600,
+      "max_retries": 2,
+      "min_retry_interval_millis": 30000
+    }
+  },
+  {
+    "id": "delete_no_recurse",
+    "description": "Delete activity - non-recursive delete",
+    "input": {
+      "name": "delete_single_file",
+      "type": "Delete",
+      "description": "Remove a single file without recursion",
+      "depends_on": [],
+      "dataset": {
+        "reference_name": "OutputDataset",
+        "type": "DatasetReference"
+      },
+      "recursive": false,
+      "folder_path": "data/output/temp"
+    },
+    "expected": {
+      "name": "delete_single_file",
+      "task_key": "delete_single_file",
+      "dataset_name": "OutputDataset",
+      "recursive": false,
+      "folder_path": "data/output/temp"
+    }
+  },
+  {
+    "id": "delete_with_wildcard",
+    "description": "Delete activity - with wildcard file name",
+    "input": {
+      "name": "delete_csv_files",
+      "type": "Delete",
+      "description": "Remove CSV files matching a wildcard pattern",
+      "depends_on": [],
+      "dataset": {
+        "reference_name": "RawDataset",
+        "type": "DatasetReference"
+      },
+      "recursive": true,
+      "store_settings": {
+        "type": "AzureBlobFSReadSettings",
+        "wildcard_file_name": "*.csv",
+        "wildcard_folder_path": "data/raw/*"
+      }
+    },
+    "expected": {
+      "name": "delete_csv_files",
+      "task_key": "delete_csv_files",
+      "dataset_name": "RawDataset",
+      "recursive": true,
+      "wildcard_file_name": "*.csv",
+      "wildcard_folder_path": "data/raw/*"
+    }
+  },
+  {
+    "id": "delete_with_logging",
+    "description": "Delete activity - with enableLogging (triggers warning)",
+    "input": {
+      "name": "delete_with_audit",
+      "type": "Delete",
+      "description": "Delete files with audit logging enabled",
+      "depends_on": [],
+      "dataset": {
+        "reference_name": "ArchiveDataset",
+        "type": "DatasetReference"
+      },
+      "recursive": true,
+      "enable_logging": true,
+      "log_storage_settings": {
+        "linked_service_name": {
+          "reference_name": "AuditStorageLink",
+          "type": "LinkedServiceReference"
+        },
+        "path": "audit-logs/delete"
+      }
+    },
+    "expected": {
+      "name": "delete_with_audit",
+      "task_key": "delete_with_audit",
+      "dataset_name": "ArchiveDataset",
+      "recursive": true
+    }
+  },
+  {
+    "id": "delete_with_dependency",
+    "description": "Delete activity - with upstream dependency",
+    "input": {
+      "name": "cleanup_after_copy",
+      "type": "Delete",
+      "description": "Clean up source files after successful copy",
+      "depends_on": [
+        {
+          "activity": "copy_to_target",
+          "dependency_conditions": ["Succeeded"]
+        }
+      ],
+      "dataset": {
+        "reference_name": "SourceDataset",
+        "type": "DatasetReference"
+      },
+      "recursive": true
+    },
+    "expected": {
+      "name": "cleanup_after_copy",
+      "task_key": "cleanup_after_copy",
+      "dataset_name": "SourceDataset",
+      "recursive": true
+    }
+  },
+  {
+    "id": "missing_dataset",
+    "description": "Delete activity - missing dataset returns UnsupportedValue",
+    "input": {
+      "name": "bad_delete",
+      "type": "Delete",
+      "recursive": true
+    },
+    "expected_unsupported": true,
+    "expected_message": "Missing value 'dataset' for Delete activity"
+  },
+  {
+    "id": "missing_dataset_reference_name",
+    "description": "Delete activity - missing dataset reference name returns UnsupportedValue",
+    "input": {
+      "name": "bad_delete_ref",
+      "type": "Delete",
+      "dataset": {
+        "type": "DatasetReference"
+      },
+      "recursive": true
+    },
+    "expected_unsupported": true,
+    "expected_message": "Missing value 'dataset.referenceName' for Delete activity"
+  }
+]

--- a/tests/unit/test_activity_translators.py
+++ b/tests/unit/test_activity_translators.py
@@ -1565,6 +1565,17 @@ def test_delete_missing_dataset_reference_name_returns_unsupported(delete_activi
     assert fixture["expected_message"] in result.message
 
 
+def test_delete_with_wildcard_folder_only(delete_activity_fixtures: list[dict]) -> None:
+    """Test translation of a Delete activity with wildcard_folder_path but no wildcard_file_name."""
+    fixture = get_fixture(delete_activity_fixtures, "delete_with_wildcard_folder_only")
+    result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.dataset_name == fixture["expected"]["dataset_name"]
+    assert result.wildcard_folder_path == fixture["expected"]["wildcard_folder_path"]
+    assert result.wildcard_file_name is None
+
+
 def test_delete_translate_activity_dispatch(delete_activity_fixtures: list[dict]) -> None:
     """Test that translate_activity dispatches Delete to the correct translator."""
     fixture = get_fixture(delete_activity_fixtures, "basic_delete")

--- a/tests/unit/test_activity_translators.py
+++ b/tests/unit/test_activity_translators.py
@@ -1487,7 +1487,7 @@ def test_copy_invalid_translator_returns_unsupported(copy_activity_fixtures: lis
 
 
 def test_basic_delete_activity(delete_activity_fixtures: list[dict]) -> None:
-    """Test translation of a basic recursive Delete activity."""
+    """Recursive Delete activity translates with correct metadata and policy."""
     fixture = get_fixture(delete_activity_fixtures, "basic_delete")
     result = translate_activity(fixture["input"])
 
@@ -1502,7 +1502,7 @@ def test_basic_delete_activity(delete_activity_fixtures: list[dict]) -> None:
 
 
 def test_delete_no_recurse(delete_activity_fixtures: list[dict]) -> None:
-    """Test translation of a Delete activity with recursive=false."""
+    """Non-recursive Delete preserves recursive=False and folder_path."""
     fixture = get_fixture(delete_activity_fixtures, "delete_no_recurse")
     result = translate_activity(fixture["input"])
 
@@ -1513,7 +1513,7 @@ def test_delete_no_recurse(delete_activity_fixtures: list[dict]) -> None:
 
 
 def test_delete_with_wildcard(delete_activity_fixtures: list[dict]) -> None:
-    """Test translation of a Delete activity with wildcard file name."""
+    """Delete with store_settings wildcards extracts both file and folder patterns."""
     fixture = get_fixture(delete_activity_fixtures, "delete_with_wildcard")
     result = translate_activity(fixture["input"])
 
@@ -1524,7 +1524,7 @@ def test_delete_with_wildcard(delete_activity_fixtures: list[dict]) -> None:
 
 
 def test_delete_with_logging_warns(delete_activity_fixtures: list[dict]) -> None:
-    """Test that enableLogging on a Delete activity emits warnings."""
+    """Delete with enableLogging and logStorageSettings emits warnings."""
     fixture = get_fixture(delete_activity_fixtures, "delete_with_logging")
 
     with pytest.warns(UserWarning):
@@ -1535,7 +1535,7 @@ def test_delete_with_logging_warns(delete_activity_fixtures: list[dict]) -> None
 
 
 def test_delete_with_dependency(delete_activity_fixtures: list[dict]) -> None:
-    """Test translation of a Delete activity with an upstream dependency."""
+    """Delete with depends_on resolves upstream task reference."""
     fixture = get_fixture(delete_activity_fixtures, "delete_with_dependency")
     result = translate_activity(fixture["input"])
 
@@ -1546,7 +1546,7 @@ def test_delete_with_dependency(delete_activity_fixtures: list[dict]) -> None:
 
 
 def test_delete_missing_dataset_returns_unsupported(delete_activity_fixtures: list[dict]) -> None:
-    """Test that a missing dataset returns UnsupportedValue."""
+    """Missing dataset key returns UnsupportedValue."""
     fixture = get_fixture(delete_activity_fixtures, "missing_dataset")
     base_kwargs = get_base_kwargs(fixture["input"])
     result = translate_delete_activity(fixture["input"], base_kwargs)
@@ -1556,7 +1556,7 @@ def test_delete_missing_dataset_returns_unsupported(delete_activity_fixtures: li
 
 
 def test_delete_missing_dataset_reference_name_returns_unsupported(delete_activity_fixtures: list[dict]) -> None:
-    """Test that a missing dataset reference name returns UnsupportedValue."""
+    """Missing dataset.referenceName returns UnsupportedValue."""
     fixture = get_fixture(delete_activity_fixtures, "missing_dataset_reference_name")
     base_kwargs = get_base_kwargs(fixture["input"])
     result = translate_delete_activity(fixture["input"], base_kwargs)
@@ -1566,7 +1566,7 @@ def test_delete_missing_dataset_reference_name_returns_unsupported(delete_activi
 
 
 def test_delete_with_wildcard_folder_only(delete_activity_fixtures: list[dict]) -> None:
-    """Test translation of a Delete activity with wildcard_folder_path but no wildcard_file_name."""
+    """Delete with wildcard_folder_path only leaves wildcard_file_name as None."""
     fixture = get_fixture(delete_activity_fixtures, "delete_with_wildcard_folder_only")
     result = translate_activity(fixture["input"])
 
@@ -1577,7 +1577,7 @@ def test_delete_with_wildcard_folder_only(delete_activity_fixtures: list[dict]) 
 
 
 def test_delete_translate_activity_dispatch(delete_activity_fixtures: list[dict]) -> None:
-    """Test that translate_activity dispatches Delete to the correct translator."""
+    """translate_activity dispatches type 'Delete' to translate_delete_activity."""
     fixture = get_fixture(delete_activity_fixtures, "basic_delete")
     result = translate_activity(fixture["input"])
 

--- a/tests/unit/test_activity_translators.py
+++ b/tests/unit/test_activity_translators.py
@@ -16,6 +16,7 @@ from wkmigrate.models.ir.pipeline import (
     CopyActivity,
     Authentication,
     DatabricksNotebookActivity,
+    DeleteActivity,
     ForEachActivity,
     IfConditionActivity,
     LookupActivity,
@@ -51,6 +52,7 @@ from wkmigrate.translators.activity_translators.spark_jar_activity_translator im
 from wkmigrate.translators.activity_translators.lookup_activity_translator import (
     translate_lookup_activity,
 )
+from wkmigrate.translators.activity_translators.delete_activity_translator import translate_delete_activity
 from wkmigrate.translators.activity_translators.web_activity_translator import translate_web_activity
 from wkmigrate.translators.activity_translators.set_variable_activity_translator import (
     translate_set_variable_activity,
@@ -1479,3 +1481,94 @@ def test_copy_invalid_translator_returns_unsupported(copy_activity_fixtures: lis
 
     assert isinstance(result, UnsupportedValue)
     assert "translator" in result.message.lower()
+
+
+# --- Delete activity tests ---
+
+
+def test_basic_delete_activity(delete_activity_fixtures: list[dict]) -> None:
+    """Test translation of a basic recursive Delete activity."""
+    fixture = get_fixture(delete_activity_fixtures, "basic_delete")
+    result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.name == fixture["expected"]["name"]
+    assert result.task_key == fixture["expected"]["task_key"]
+    assert result.dataset_name == fixture["expected"]["dataset_name"]
+    assert result.recursive is True
+    assert result.timeout_seconds == fixture["expected"]["timeout_seconds"]
+    assert result.max_retries == fixture["expected"]["max_retries"]
+    assert result.min_retry_interval_millis == fixture["expected"]["min_retry_interval_millis"]
+
+
+def test_delete_no_recurse(delete_activity_fixtures: list[dict]) -> None:
+    """Test translation of a Delete activity with recursive=false."""
+    fixture = get_fixture(delete_activity_fixtures, "delete_no_recurse")
+    result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.dataset_name == fixture["expected"]["dataset_name"]
+    assert result.recursive is False
+    assert result.folder_path == fixture["expected"]["folder_path"]
+
+
+def test_delete_with_wildcard(delete_activity_fixtures: list[dict]) -> None:
+    """Test translation of a Delete activity with wildcard file name."""
+    fixture = get_fixture(delete_activity_fixtures, "delete_with_wildcard")
+    result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.dataset_name == fixture["expected"]["dataset_name"]
+    assert result.wildcard_file_name == fixture["expected"]["wildcard_file_name"]
+    assert result.wildcard_folder_path == fixture["expected"]["wildcard_folder_path"]
+
+
+def test_delete_with_logging_warns(delete_activity_fixtures: list[dict]) -> None:
+    """Test that enableLogging on a Delete activity emits warnings."""
+    fixture = get_fixture(delete_activity_fixtures, "delete_with_logging")
+
+    with pytest.warns(UserWarning):
+        result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.dataset_name == fixture["expected"]["dataset_name"]
+
+
+def test_delete_with_dependency(delete_activity_fixtures: list[dict]) -> None:
+    """Test translation of a Delete activity with an upstream dependency."""
+    fixture = get_fixture(delete_activity_fixtures, "delete_with_dependency")
+    result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.depends_on is not None
+    assert len(result.depends_on) == 1
+    assert result.depends_on[0].task_key == "copy_to_target"
+
+
+def test_delete_missing_dataset_returns_unsupported(delete_activity_fixtures: list[dict]) -> None:
+    """Test that a missing dataset returns UnsupportedValue."""
+    fixture = get_fixture(delete_activity_fixtures, "missing_dataset")
+    base_kwargs = get_base_kwargs(fixture["input"])
+    result = translate_delete_activity(fixture["input"], base_kwargs)
+
+    assert isinstance(result, UnsupportedValue)
+    assert fixture["expected_message"] in result.message
+
+
+def test_delete_missing_dataset_reference_name_returns_unsupported(delete_activity_fixtures: list[dict]) -> None:
+    """Test that a missing dataset reference name returns UnsupportedValue."""
+    fixture = get_fixture(delete_activity_fixtures, "missing_dataset_reference_name")
+    base_kwargs = get_base_kwargs(fixture["input"])
+    result = translate_delete_activity(fixture["input"], base_kwargs)
+
+    assert isinstance(result, UnsupportedValue)
+    assert fixture["expected_message"] in result.message
+
+
+def test_delete_translate_activity_dispatch(delete_activity_fixtures: list[dict]) -> None:
+    """Test that translate_activity dispatches Delete to the correct translator."""
+    fixture = get_fixture(delete_activity_fixtures, "basic_delete")
+    result = translate_activity(fixture["input"])
+
+    assert isinstance(result, DeleteActivity)
+    assert result.dataset_name == fixture["expected"]["dataset_name"]

--- a/tests/unit/test_preparer.py
+++ b/tests/unit/test_preparer.py
@@ -485,3 +485,122 @@ def test_prepare_workflow_dispatches_delete_activity() -> None:
     assert len(result.activities) == 1
     assert result.activities[0].notebooks is not None
     assert "dbutils.fs.rm" in result.activities[0].notebooks[0].content
+
+
+# --- setup_tasks tests ---
+
+
+def test_delete_preparer_produces_setup_task_with_folder_path() -> None:
+    """When folder_path is set, a setup task creating a UC external volume is returned."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert result.setup_tasks is not None
+    assert len(result.setup_tasks) == 1
+    setup = result.setup_tasks[0]
+    assert "setup_volume_" in setup.task["task_key"]
+    assert setup.notebooks is not None
+    assert "CREATE EXTERNAL VOLUME IF NOT EXISTS" in setup.notebooks[0].content
+
+
+def test_delete_preparer_no_setup_task_without_folder_path() -> None:
+    """When folder_path is None, no setup tasks are emitted."""
+    activity = DeleteActivity(
+        name="NoPathDelete",
+        task_key="no_path_delete",
+        dataset_name="StagingDataset",
+        recursive=True,
+    )
+
+    result = prepare_delete_activity(activity)
+
+    assert result.setup_tasks is None
+
+
+def test_delete_preparer_setup_task_uses_custom_catalog_schema() -> None:
+    """Setup task respects provided catalog and schema."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity, catalog="prod_catalog", schema="prod_schema")
+
+    assert result.setup_tasks is not None
+    notebook_content = result.setup_tasks[0].notebooks[0].content
+    assert "prod_catalog" in notebook_content
+    assert "prod_schema" in notebook_content
+
+
+def test_delete_preparer_setup_task_defaults_catalog_schema() -> None:
+    """Setup task falls back to default catalog/schema when not provided."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert result.setup_tasks is not None
+    notebook_content = result.setup_tasks[0].notebooks[0].content
+    assert "'main'" in notebook_content
+    assert "'default'" in notebook_content
+
+
+def test_delete_preparer_setup_notebook_path() -> None:
+    """Setup notebook uses a distinct path under /wkmigrate/setup_notebooks/."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert result.setup_tasks is not None
+    assert result.setup_tasks[0].notebooks[0].file_path == "/wkmigrate/setup_notebooks/create_volume_deletetest"
+
+
+def test_prepare_workflow_collects_setup_tasks() -> None:
+    """prepare_workflow aggregates setup_tasks from individual activities."""
+    pipeline = Pipeline(
+        name="test_delete_pipeline",
+        tasks=[_make_delete_activity()],
+        parameters=None,
+        schedule=None,
+        tags={},
+    )
+
+    result = prepare_workflow(pipeline)
+
+    assert result.setup_tasks is not None
+    assert len(result.setup_tasks) == 1
+    assert "CREATE EXTERNAL VOLUME IF NOT EXISTS" in result.setup_tasks[0].notebooks[0].content
+
+
+def test_prepare_workflow_no_setup_tasks_without_delete() -> None:
+    """prepare_workflow returns None for setup_tasks when no activities produce them."""
+    pipeline = _make_pipeline_with_lookup()
+
+    result = prepare_workflow(pipeline)
+
+    assert result.setup_tasks is None
+
+
+def test_all_setup_tasks_property_includes_activity_level() -> None:
+    """PreparedWorkflow.all_setup_tasks includes setup tasks from individual activities."""
+    activity = _make_delete_activity()
+
+    pipeline = Pipeline(
+        name="test_pipeline",
+        tasks=[activity],
+        parameters=None,
+        schedule=None,
+        tags={},
+    )
+    workflow = prepare_workflow(pipeline)
+
+    assert len(workflow.all_setup_tasks) >= 1
+    assert any("CREATE EXTERNAL VOLUME" in st.notebooks[0].content for st in workflow.all_setup_tasks if st.notebooks)
+
+
+def test_setup_task_notebook_is_idempotent_sql() -> None:
+    """The setup notebook uses IF NOT EXISTS so it is safe to rerun."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert result.setup_tasks is not None
+    content = result.setup_tasks[0].notebooks[0].content
+    assert "IF NOT EXISTS" in content

--- a/tests/unit/test_preparer.py
+++ b/tests/unit/test_preparer.py
@@ -8,6 +8,7 @@ from wkmigrate.models.ir.pipeline import (
     Authentication,
     ColumnMapping,
     CopyActivity,
+    DeleteActivity,
     ForEachActivity,
     LookupActivity,
     Pipeline,
@@ -15,6 +16,7 @@ from wkmigrate.models.ir.pipeline import (
     WebActivity,
 )
 from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
+from wkmigrate.preparers.delete_activity_preparer import prepare_delete_activity
 from wkmigrate.preparers.for_each_activity_preparer import prepare_for_each_activity
 from wkmigrate.preparers.lookup_activity_preparer import prepare_lookup_activity
 from wkmigrate.preparers.preparer import prepare_workflow
@@ -321,3 +323,94 @@ def _make_run_job_with_lookup_pipeline(name: str = "RunJobTest") -> RunJobActivi
         task_key=name.lower(),
         pipeline=_make_pipeline_with_lookup(),
     )
+
+
+def _make_delete_activity(name: str = "DeleteTest") -> DeleteActivity:
+    return DeleteActivity(
+        name=name,
+        task_key=name.lower(),
+        dataset_name="StagingDataset",
+        folder_path="data/staging",
+        recursive=True,
+    )
+
+
+def test_delete_preparer_produces_notebook() -> None:
+    """prepare_delete_activity produces a notebook with dbutils.fs.rm."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert result.notebooks is not None
+    assert len(result.notebooks) == 1
+    notebook_content = result.notebooks[0].content
+    assert "dbutils.fs.rm" in notebook_content
+    assert "data/staging" in notebook_content
+
+
+def test_delete_preparer_notebook_path() -> None:
+    """prepare_delete_activity sets the correct notebook path."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert result.notebooks[0].file_path == "/wkmigrate/delete_activity_notebooks/deletetest"
+
+
+def test_delete_preparer_task_has_notebook_task() -> None:
+    """prepare_delete_activity creates a task with a notebook_task entry."""
+    activity = _make_delete_activity()
+
+    result = prepare_delete_activity(activity)
+
+    assert "notebook_task" in result.task
+    assert result.task["notebook_task"]["notebook_path"] == "/wkmigrate/delete_activity_notebooks/deletetest"
+
+
+def test_delete_preparer_recursive_flag_in_notebook() -> None:
+    """prepare_delete_activity includes the recursive flag in the notebook content."""
+    activity = DeleteActivity(
+        name="NonRecursiveDelete",
+        task_key="non_recursive_delete",
+        dataset_name="TestDataset",
+        recursive=False,
+    )
+
+    result = prepare_delete_activity(activity)
+
+    notebook_content = result.notebooks[0].content
+    assert "recurse=False" in notebook_content
+
+
+def test_delete_preparer_wildcard_in_notebook() -> None:
+    """prepare_delete_activity includes wildcard logic in the notebook when wildcard is set."""
+    activity = DeleteActivity(
+        name="WildcardDelete",
+        task_key="wildcard_delete",
+        dataset_name="TestDataset",
+        wildcard_file_name="*.csv",
+        recursive=True,
+    )
+
+    result = prepare_delete_activity(activity)
+
+    notebook_content = result.notebooks[0].content
+    assert "fnmatch" in notebook_content
+    assert "*.csv" in notebook_content
+
+
+def test_prepare_workflow_dispatches_delete_activity() -> None:
+    """prepare_workflow correctly dispatches a DeleteActivity."""
+    pipeline = Pipeline(
+        name="test_delete_pipeline",
+        tasks=[_make_delete_activity()],
+        parameters=None,
+        schedule=None,
+        tags={},
+    )
+
+    result = prepare_workflow(pipeline)
+
+    assert len(result.activities) == 1
+    assert result.activities[0].notebooks is not None
+    assert "dbutils.fs.rm" in result.activities[0].notebooks[0].content

--- a/tests/unit/test_preparer.py
+++ b/tests/unit/test_preparer.py
@@ -467,7 +467,8 @@ def test_delete_preparer_missing_folder_path_emits_warning() -> None:
 
     notebook_content = result.notebooks[0].content
     assert "TODO" in notebook_content
-    assert "UNRESOLVED_PATH_FOR_StagingDataset" in notebook_content
+    assert "UNRESOLVED_PATH_FOR_" in notebook_content
+    assert "'StagingDataset'" in notebook_content
 
 
 def test_prepare_workflow_dispatches_delete_activity() -> None:
@@ -591,7 +592,7 @@ def test_all_setup_tasks_property_includes_activity_level() -> None:
     )
     workflow = prepare_workflow(pipeline)
 
-    assert len(workflow.all_setup_tasks) >= 1
+    assert len(workflow.all_setup_tasks) == 1
     assert any("CREATE EXTERNAL VOLUME" in st.notebooks[0].content for st in workflow.all_setup_tasks if st.notebooks)
 
 

--- a/tests/unit/test_preparer.py
+++ b/tests/unit/test_preparer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from wkmigrate.code_generator import DEFAULT_CREDENTIALS_SCOPE
 from wkmigrate.definition_stores.workspace_definition_store import WorkspaceDefinitionStore
 from wkmigrate.models.ir.pipeline import (
@@ -15,6 +17,7 @@ from wkmigrate.models.ir.pipeline import (
     RunJobActivity,
     WebActivity,
 )
+from wkmigrate.not_translatable import NotTranslatableWarning
 from wkmigrate.preparers.copy_activity_preparer import prepare_copy_activity
 from wkmigrate.preparers.delete_activity_preparer import prepare_delete_activity
 from wkmigrate.preparers.for_each_activity_preparer import prepare_for_each_activity
@@ -336,7 +339,7 @@ def _make_delete_activity(name: str = "DeleteTest") -> DeleteActivity:
 
 
 def test_delete_preparer_produces_notebook() -> None:
-    """prepare_delete_activity produces a notebook with dbutils.fs.rm."""
+    """Notebook contains dbutils.fs.rm and the resolved folder path."""
     activity = _make_delete_activity()
 
     result = prepare_delete_activity(activity)
@@ -349,7 +352,7 @@ def test_delete_preparer_produces_notebook() -> None:
 
 
 def test_delete_preparer_notebook_path() -> None:
-    """prepare_delete_activity sets the correct notebook path."""
+    """Notebook artifact path uses the activity task_key."""
     activity = _make_delete_activity()
 
     result = prepare_delete_activity(activity)
@@ -358,7 +361,7 @@ def test_delete_preparer_notebook_path() -> None:
 
 
 def test_delete_preparer_task_has_notebook_task() -> None:
-    """prepare_delete_activity creates a task with a notebook_task entry."""
+    """Task payload includes notebook_task pointing to the generated notebook."""
     activity = _make_delete_activity()
 
     result = prepare_delete_activity(activity)
@@ -368,7 +371,7 @@ def test_delete_preparer_task_has_notebook_task() -> None:
 
 
 def test_delete_preparer_recursive_flag_in_notebook() -> None:
-    """prepare_delete_activity includes the recursive flag in the notebook content."""
+    """Notebook respects recursive=False in the dbutils.fs.rm call."""
     activity = DeleteActivity(
         name="NonRecursiveDelete",
         task_key="non_recursive_delete",
@@ -383,7 +386,7 @@ def test_delete_preparer_recursive_flag_in_notebook() -> None:
 
 
 def test_delete_preparer_wildcard_in_notebook() -> None:
-    """prepare_delete_activity includes wildcard logic in the notebook when wildcard is set."""
+    """Notebook uses fnmatch filtering when wildcard_file_name is set."""
     activity = DeleteActivity(
         name="WildcardDelete",
         task_key="wildcard_delete",
@@ -400,7 +403,7 @@ def test_delete_preparer_wildcard_in_notebook() -> None:
 
 
 def test_delete_preparer_wildcard_folder_only() -> None:
-    """prepare_delete_activity generates folder-wildcard filtering when only wildcard_folder_path is set."""
+    """Notebook filters folders by wildcard_folder_path when wildcard_file_name is absent."""
     activity = DeleteActivity(
         name="FolderWildcardDelete",
         task_key="folder_wildcard_delete",
@@ -421,7 +424,7 @@ def test_delete_preparer_wildcard_folder_only() -> None:
 
 
 def test_delete_preparer_two_level_wildcard() -> None:
-    """prepare_delete_activity generates two-level filtering when both wildcards are set."""
+    """Notebook uses two-level listing when both wildcard_folder_path and wildcard_file_name are set."""
     activity = DeleteActivity(
         name="TwoLevelDelete",
         task_key="two_level_delete",
@@ -445,11 +448,7 @@ def test_delete_preparer_two_level_wildcard() -> None:
 
 
 def test_delete_preparer_missing_folder_path_emits_warning() -> None:
-    """prepare_delete_activity emits NotTranslatableWarning when folder_path is None."""
-    import warnings
-
-    from wkmigrate.not_translatable import NotTranslatableWarning
-
+    """Unresolved folder_path emits NotTranslatableWarning and inserts a TODO placeholder."""
     activity = DeleteActivity(
         name="NoPathDelete",
         task_key="no_path_delete",
@@ -472,7 +471,7 @@ def test_delete_preparer_missing_folder_path_emits_warning() -> None:
 
 
 def test_prepare_workflow_dispatches_delete_activity() -> None:
-    """prepare_workflow correctly dispatches a DeleteActivity."""
+    """prepare_workflow routes DeleteActivity to prepare_delete_activity."""
     pipeline = Pipeline(
         name="test_delete_pipeline",
         tasks=[_make_delete_activity()],

--- a/tests/unit/test_preparer.py
+++ b/tests/unit/test_preparer.py
@@ -399,6 +399,78 @@ def test_delete_preparer_wildcard_in_notebook() -> None:
     assert "*.csv" in notebook_content
 
 
+def test_delete_preparer_wildcard_folder_only() -> None:
+    """prepare_delete_activity generates folder-wildcard filtering when only wildcard_folder_path is set."""
+    activity = DeleteActivity(
+        name="FolderWildcardDelete",
+        task_key="folder_wildcard_delete",
+        dataset_name="TestDataset",
+        folder_path="data/archive",
+        recursive=True,
+        wildcard_folder_path="2023-*",
+    )
+
+    result = prepare_delete_activity(activity)
+
+    notebook_content = result.notebooks[0].content
+    assert "fnmatch" in notebook_content
+    assert "2023-*" in notebook_content
+    assert "folders = dbutils.fs.ls(path)" in notebook_content
+    assert "fnmatch.fnmatch(folder.name, wildcard_folder_path)" in notebook_content
+    assert "dbutils.fs.rm(folder.path" in notebook_content
+
+
+def test_delete_preparer_two_level_wildcard() -> None:
+    """prepare_delete_activity generates two-level filtering when both wildcards are set."""
+    activity = DeleteActivity(
+        name="TwoLevelDelete",
+        task_key="two_level_delete",
+        dataset_name="TestDataset",
+        folder_path="data/raw",
+        recursive=True,
+        wildcard_file_name="*.csv",
+        wildcard_folder_path="data/raw/*",
+    )
+
+    result = prepare_delete_activity(activity)
+
+    notebook_content = result.notebooks[0].content
+    assert "fnmatch" in notebook_content
+    assert "wildcard_folder_path" in notebook_content
+    assert "wildcard_file_name" in notebook_content
+    assert "folders = dbutils.fs.ls(path)" in notebook_content
+    assert "files = dbutils.fs.ls(folder.path)" in notebook_content
+    assert "fnmatch.fnmatch(folder.name, wildcard_folder_path)" in notebook_content
+    assert "fnmatch.fnmatch(f.name, wildcard_file_name)" in notebook_content
+
+
+def test_delete_preparer_missing_folder_path_emits_warning() -> None:
+    """prepare_delete_activity emits NotTranslatableWarning when folder_path is None."""
+    import warnings
+
+    from wkmigrate.not_translatable import NotTranslatableWarning
+
+    activity = DeleteActivity(
+        name="NoPathDelete",
+        task_key="no_path_delete",
+        dataset_name="StagingDataset",
+        recursive=True,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = prepare_delete_activity(activity)
+
+    warning_messages = [w for w in caught if issubclass(w.category, NotTranslatableWarning)]
+    assert len(warning_messages) == 1
+    assert "StagingDataset" in str(warning_messages[0].message)
+    assert "could not be resolved" in str(warning_messages[0].message)
+
+    notebook_content = result.notebooks[0].content
+    assert "TODO" in notebook_content
+    assert "UNRESOLVED_PATH_FOR_StagingDataset" in notebook_content
+
+
 def test_prepare_workflow_dispatches_delete_activity() -> None:
     """prepare_workflow correctly dispatches a DeleteActivity."""
     pipeline = Pipeline(


### PR DESCRIPTION
## Changes

- Add `DeleteActivity` IR model extending `Activity` with dataset_name, folder_path, recursive, wildcard_file_name, and wildcard_folder_path fields
- Add `delete_activity_translator.py` to extract Delete activity properties from ADF JSON and emit `NotTranslatableWarning` for unsupported `enableLogging` and `logStorageSettings` features
- Add `delete_activity_preparer.py` to generate a Python notebook that uses `dbutils.fs.rm()` for file/folder deletion, with wildcard support via `fnmatch`
- Register the translator as `"Delete"` in the activity translator registry and the preparer in the activity dispatch chain
- Add 7 fixture definitions and 8 translator tests plus 6 preparer tests

### Linked issues

Closes #70 

### Tests

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests