### PR TITLE
Fix translation of Copy activities

### DIFF
--- a/src/wkmigrate/definition_stores/factory_definition_store.py
+++ b/src/wkmigrate/definition_stores/factory_definition_store.py
@@ -31,6 +31,7 @@ from wkmigrate.definition_stores.pipeline_adapter import PipelineAdapter
 from wkmigrate.enums.source_property_case import SourcePropertyCase
 from wkmigrate.models.ir.pipeline import Pipeline
 from wkmigrate.translators.pipeline_translators.pipeline_translator import translate_pipeline
+from wkmigrate.utils import normalize_arm_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ class FactoryDefinitionStore(DefinitionStore):
         normalized = self._adapter.normalize_casing(pipeline)
         if normalized is not None:
             pipeline = normalized
+        pipeline = normalize_arm_pipeline(pipeline)
         trigger = self._client.get_trigger(pipeline_name)
 
         enriched = self._adapter.adapt(pipeline, trigger)

--- a/src/wkmigrate/definition_stores/pipeline_adapter.py
+++ b/src/wkmigrate/definition_stores/pipeline_adapter.py
@@ -157,9 +157,7 @@ class PipelineAdapter:
             raw = self.get_linked_service(linked_service_name)
             definition = self.normalize_casing(raw, ("linked_service", linked_service_name))
         except ValueError:
-            logger.warning(
-                f"Linked service '{linked_service_name}' not found; skipping cluster spec for activity."
-            )
+            logger.warning(f"Linked service '{linked_service_name}' not found; skipping cluster spec for activity.")
             return activity
 
         return {**activity, "linked_service_definition": definition}

--- a/src/wkmigrate/definition_stores/pipeline_adapter.py
+++ b/src/wkmigrate/definition_stores/pipeline_adapter.py
@@ -83,7 +83,8 @@ class PipelineAdapter:
 
     def _enrich_activity(self, activity: dict) -> dict:
         """
-        Returns an activity dict enriched with datasets and linked services.
+        Returns an activity dict enriched with datasets, linked services, and
+        recursively enriched nested activities (e.g. inside ForEach or IfCondition).
 
         Args:
             activity: Input activity as a dictionary.
@@ -93,6 +94,7 @@ class PipelineAdapter:
         """
         result = self._enrich_datasets(activity)
         result = self._enrich_linked_service(result)
+        result = self._enrich_nested_activities(result)
         return result
 
     def _enrich_datasets(self, activity: dict) -> dict:
@@ -135,7 +137,7 @@ class PipelineAdapter:
 
     def _enrich_linked_service(self, activity: dict) -> dict:
         """
-        Returns an activity dictionary with linked-service definitions and enriched nested activities.
+        Returns an activity dictionary with linked-service definitions populated.
 
         Args:
             activity: Input activity as a dictionary.
@@ -143,26 +145,42 @@ class PipelineAdapter:
         Returns:
             Activity with linked service metadata.
         """
-        additions: dict = {}
-
         linked_service_reference = activity.get("linked_service_name")
-        if linked_service_reference is not None:
-            linked_service_name = linked_service_reference.get("reference_name")
-            if linked_service_name:
-                try:
-                    raw = self.get_linked_service(linked_service_name)
-                    additions["linked_service_definition"] = self.normalize_casing(
-                        raw, ("linked_service", linked_service_name)
-                    )
-                except ValueError:
-                    logger.warning(
-                        f"Linked service '{linked_service_name}' not found; skipping cluster spec for activity."
-                    )
+        if linked_service_reference is None:
+            return activity
 
+        linked_service_name = linked_service_reference.get("reference_name")
+        if not linked_service_name:
+            return activity
+
+        try:
+            raw = self.get_linked_service(linked_service_name)
+            definition = self.normalize_casing(raw, ("linked_service", linked_service_name))
+        except ValueError:
+            logger.warning(
+                f"Linked service '{linked_service_name}' not found; skipping cluster spec for activity."
+            )
+            return activity
+
+        return {**activity, "linked_service_definition": definition}
+
+    def _enrich_nested_activities(self, activity: dict) -> dict:
+        """
+        Recursively enriches nested activities within control-flow constructs
+        (ForEach, IfCondition) so that inner activities receive dataset and
+        linked-service metadata.
+
+        Args:
+            activity: Input activity as a dictionary.
+
+        Returns:
+            Activity with enriched nested activities.
+        """
+        additions: dict = {}
         for branch_key in ("if_false_activities", "if_true_activities", "activities"):
             branch = activity.get(branch_key)
             if branch is not None:
-                additions[branch_key] = [self._enrich_linked_service(branch_activity) for branch_activity in branch]
+                additions[branch_key] = [self._enrich_activity(nested) for nested in branch]
 
         if not additions:
             return activity

--- a/src/wkmigrate/translators/dataset_translators/utils.py
+++ b/src/wkmigrate/translators/dataset_translators/utils.py
@@ -110,6 +110,9 @@ def parse_cloud_file_path(properties: dict) -> str | UnsupportedValue:
     """
     Parses the file path from a cloud dataset definition.
 
+    Accepts datasets with only a ``folder_path`` (common for wildcard or
+    directory-level reads), only a ``file_name``, or both.
+
     Args:
         properties: File properties from the dataset definition.
 
@@ -122,15 +125,25 @@ def parse_cloud_file_path(properties: dict) -> str | UnsupportedValue:
 
     folder_path = location.get("folder_path")
     file_name = location.get("file_name")
-    if file_name is None:
-        return UnsupportedValue(value=properties, message="Missing property 'file_name' in dataset properties")
 
-    return file_name if not folder_path else f"{folder_path}/{file_name}"
+    if folder_path and file_name:
+        return f"{folder_path}/{file_name}"
+    if file_name:
+        return file_name
+    if folder_path:
+        return folder_path
+    return UnsupportedValue(
+        value=properties,
+        message="Missing both 'folder_path' and 'file_name' in dataset location",
+    )
 
 
 def parse_abfs_file_path(properties: dict) -> str | UnsupportedValue:
     """
     Parses the ABFS file path from a dataset definition.
+
+    Accepts datasets with only a ``folder_path`` (common for wildcard or
+    directory-level reads), only a ``file_name``, or both.
 
     Args:
         properties: File properties from the dataset definition.
@@ -144,10 +157,17 @@ def parse_abfs_file_path(properties: dict) -> str | UnsupportedValue:
 
     folder_path = location.get("folder_path")
     file_name = location.get("file_name")
-    if file_name is None:
-        return UnsupportedValue(value=properties, message="Missing property 'file_name' in dataset properties")
 
-    return file_name if not folder_path else f"{folder_path}/{file_name}"
+    if folder_path and file_name:
+        return f"{folder_path}/{file_name}"
+    if file_name:
+        return file_name
+    if folder_path:
+        return folder_path
+    return UnsupportedValue(
+        value=properties,
+        message="Missing both 'folder_path' and 'file_name' in dataset location",
+    )
 
 
 def _parse_avro_format_options(dataset: dict) -> dict:

--- a/src/wkmigrate/utils.py
+++ b/src/wkmigrate/utils.py
@@ -416,4 +416,11 @@ def _normalize_activity_type_properties(activity: dict) -> dict:
             if converted_key in activity:
                 continue
             activity[converted_key] = original_value
+
+    for branch_key in ("if_false_activities", "if_true_activities", "activities"):
+        branch = activity.get(branch_key)
+        if isinstance(branch, list):
+            activity[branch_key] = [
+                _normalize_activity_type_properties(dict(nested)) for nested in branch if isinstance(nested, dict)
+            ]
     return activity

--- a/tests/unit/test_cloud_dataset_translators.py
+++ b/tests/unit/test_cloud_dataset_translators.py
@@ -222,8 +222,8 @@ def test_translate_gcs_dataset_parquet() -> None:
     assert result.provider_type == "gcs"
 
 
-def test_translate_gcs_dataset_missing_file_name() -> None:
-    """Test GCS dataset with missing file_name returns UnsupportedValue."""
+def test_translate_gcs_dataset_folder_path_only() -> None:
+    """Test GCS dataset with only folder_path (no file_name) uses folder_path as the path."""
     dataset = {
         "name": "gcs_no_file",
         "properties": {
@@ -238,8 +238,27 @@ def test_translate_gcs_dataset_missing_file_name() -> None:
     }
     result = translate_file_dataset("DelimitedText", dataset, "gcs")
 
+    assert isinstance(result, FileDataset)
+    assert result.folder_path == "data"
+
+
+def test_translate_gcs_dataset_missing_both_path_fields() -> None:
+    """Test GCS dataset with neither folder_path nor file_name returns UnsupportedValue."""
+    dataset = {
+        "name": "gcs_no_path",
+        "properties": {
+            "type": "DelimitedText",
+            "location": {
+                "type": "GoogleCloudStorageLocation",
+                "bucket_name": "my-bucket",
+            },
+        },
+        "linked_service_definition": {"name": "svc", "properties": {}},
+    }
+    result = translate_file_dataset("DelimitedText", dataset, "gcs")
+
     assert isinstance(result, UnsupportedValue)
-    assert "file_name" in result.message
+    assert "folder_path" in result.message and "file_name" in result.message
 
 
 def test_translate_gcs_dataset_null_returns_unsupported() -> None:

--- a/tests/unit/test_definition_store.py
+++ b/tests/unit/test_definition_store.py
@@ -9,6 +9,7 @@ import yaml
 from wkmigrate.definition_stores.definition_store import DefinitionStore
 from wkmigrate.definition_stores.factory_definition_store import FactoryDefinitionStore
 from wkmigrate.definition_stores.json_definition_store import JsonDefinitionStore
+from wkmigrate.definition_stores.pipeline_adapter import PipelineAdapter
 from wkmigrate.definition_stores.workspace_definition_store import WorkspaceDefinitionStore
 from wkmigrate.models.ir.pipeline import (
     DatabricksNotebookActivity,
@@ -19,6 +20,7 @@ from wkmigrate.models.ir.pipeline import (
 )
 from wkmigrate.models.workflows.artifacts import NotebookArtifact, PreparedActivity, PreparedWorkflow
 from wkmigrate.models.workflows.instructions import PipelineInstruction
+from wkmigrate.utils import _normalize_activity_type_properties
 
 _CAMEL_JSON_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "resources", "json", "camel")
 
@@ -923,3 +925,231 @@ def test_download_notebooks_with_root_path_rewrites_inner_workflow_tasks(mock_wo
     for task in inner_tasks:
         nb_path = task.get('notebook_task', {}).get('notebook_path', '')
         assert nb_path.startswith('/migrated/'), f"Expected /migrated/ prefix, got: {nb_path}"
+
+
+# --- FactoryDefinitionStore Copy activity normalization tests ---
+
+
+def test_factory_store_normalizes_copy_activity_type_properties(monkeypatch) -> None:
+    """Copy activities from the ADF API have source/sink inside type_properties.
+
+    FactoryDefinitionStore.load() must flatten type_properties so the copy
+    translator can find source, sink, and translator at the activity root.
+    """
+    from wkmigrate.definition_stores import factory_definition_store
+    from wkmigrate.models.ir.pipeline import CopyActivity
+
+    # Simulate the format returned by Azure SDK's as_dict() — activities
+    # have type_properties wrapping source/sink, and inputs/outputs at root.
+    api_pipeline = {
+        "name": "pl_copy_csv_to_delta",
+        "activities": [
+            {
+                "name": "copy_csv",
+                "type": "Copy",
+                "type_properties": {
+                    "source": {"type": "DelimitedTextSource"},
+                    "sink": {"type": "AzureDatabricksDeltaLakeSink"},
+                },
+                "inputs": [{"reference_name": "src_csv", "type": "DatasetReference"}],
+                "outputs": [{"reference_name": "sink_delta", "type": "DatasetReference"}],
+            }
+        ],
+    }
+
+    datasets = {
+        "src_csv": {
+            "name": "src_csv",
+            "properties": {
+                "type": "DelimitedText",
+                "location": {
+                    "type": "AzureBlobFSLocation",
+                    "container": "raw",
+                    "folder_path": "csv",
+                },
+                "first_row_as_header": True,
+                "column_delimiter": ",",
+            },
+            "linked_service_definition": {
+                "name": "ls_storage",
+                "properties": {
+                    "type": "AzureBlobFS",
+                    "url": "DefaultEndpointsProtocol=https;AccountName=sourceaccount;EndpointSuffix=core.windows.net;",
+                    "storage_account_name": "DefaultEndpointsProtocol=https;AccountName=sourceaccount;EndpointSuffix=core.windows.net;",
+                },
+            },
+        },
+        "sink_delta": {
+            "name": "sink_delta",
+            "properties": {
+                "type": "AzureDatabricksDeltaLakeDataset",
+                "database": "db",
+                "table": "tbl",
+            },
+            "linked_service_definition": {
+                "name": "ls_dbx",
+                "properties": {
+                    "type": "AzureDatabricks",
+                    "domain": "https://adb-123.azuredatabricks.net",
+                },
+            },
+        },
+    }
+
+    class _FakeClient:
+        def __init__(self, **_):
+            pass
+
+        def list_pipelines(self):
+            return ["pl_copy_csv_to_delta"]
+
+        def get_pipeline(self, name):
+            return api_pipeline
+
+        def get_trigger(self, name):
+            return None
+
+        def get_dataset(self, name):
+            if name in datasets:
+                return datasets[name]
+            raise ValueError(f"Dataset '{name}' not found")
+
+        def get_linked_service(self, name):
+            raise ValueError(f"Linked service '{name}' not found")
+
+    monkeypatch.setattr(factory_definition_store, "FactoryClient", _FakeClient)
+
+    store = FactoryDefinitionStore(
+        tenant_id="T",
+        client_id="C",
+        client_secret="S",
+        subscription_id="SUB",
+        resource_group_name="RG",
+        factory_name="ADF",
+    )
+
+    pipeline = store.load("pl_copy_csv_to_delta")
+    assert len(pipeline.tasks) == 1
+    task = pipeline.tasks[0]
+    assert isinstance(task, CopyActivity), (
+        f"Expected CopyActivity but got {type(task).__name__}. "
+        "Copy activities with type_properties are being treated as unsupported."
+    )
+    assert task.source_dataset.dataset_type == "DelimitedText"
+    assert task.sink_dataset.dataset_type == "delta"
+
+
+# --- PipelineAdapter nested enrichment tests ---
+
+
+def _make_adapter(datasets: dict[str, dict], linked_services: dict[str, dict] | None = None) -> PipelineAdapter:
+    """Create a PipelineAdapter with in-memory dataset/linked-service lookups."""
+
+    def get_dataset(name: str) -> dict:
+        if name not in datasets:
+            raise ValueError(f"Dataset '{name}' not found")
+        return datasets[name]
+
+    def get_linked_service(name: str) -> dict:
+        if linked_services and name in linked_services:
+            return linked_services[name]
+        raise ValueError(f"Linked service '{name}' not found")
+
+    return PipelineAdapter(get_dataset=get_dataset, get_linked_service=get_linked_service)
+
+
+def test_adapter_enriches_nested_copy_in_foreach() -> None:
+    """Copy activities nested inside ForEach should get input/output dataset definitions."""
+    source_ds = {"name": "src", "properties": {"type": "Parquet", "location": {"type": "AzureBlobFSLocation"}}}
+    sink_ds = {"name": "snk", "properties": {"type": "AzureDatabricksDeltaLakeDataset", "table": "t"}}
+    adapter = _make_adapter({"src": source_ds, "snk": sink_ds})
+
+    pipeline = {
+        "activities": [
+            {
+                "name": "loop",
+                "type": "ForEach",
+                "items": {"value": "@array(['a'])"},
+                "activities": [
+                    {
+                        "name": "copy_inner",
+                        "type": "Copy",
+                        "inputs": [{"reference_name": "src", "type": "DatasetReference"}],
+                        "outputs": [{"reference_name": "snk", "type": "DatasetReference"}],
+                        "source": {"type": "ParquetSource"},
+                        "sink": {"type": "AzureDatabricksDeltaLakeSink"},
+                    }
+                ],
+            }
+        ]
+    }
+    enriched = adapter.adapt(pipeline)
+    inner_copy = enriched["activities"][0]["activities"][0]
+    assert "input_dataset_definitions" in inner_copy
+    assert "output_dataset_definitions" in inner_copy
+    assert inner_copy["input_dataset_definitions"][0]["name"] == "src"
+    assert inner_copy["output_dataset_definitions"][0]["name"] == "snk"
+
+
+def test_adapter_enriches_nested_copy_in_if_condition() -> None:
+    """Copy activities inside IfCondition branches should get dataset definitions."""
+    ds = {"name": "ds1", "properties": {"type": "DelimitedText", "location": {"type": "AzureBlobFSLocation"}}}
+    adapter = _make_adapter({"ds1": ds})
+
+    pipeline = {
+        "activities": [
+            {
+                "name": "branch",
+                "type": "IfCondition",
+                "if_true_activities": [
+                    {
+                        "name": "copy_true",
+                        "type": "Copy",
+                        "inputs": [{"reference_name": "ds1", "type": "DatasetReference"}],
+                        "source": {"type": "DelimitedTextSource"},
+                        "sink": {"type": "ParquetSink"},
+                    }
+                ],
+                "if_false_activities": [
+                    {
+                        "name": "copy_false",
+                        "type": "Copy",
+                        "inputs": [{"reference_name": "ds1", "type": "DatasetReference"}],
+                        "source": {"type": "DelimitedTextSource"},
+                        "sink": {"type": "ParquetSink"},
+                    }
+                ],
+            }
+        ]
+    }
+    enriched = adapter.adapt(pipeline)
+    true_copy = enriched["activities"][0]["if_true_activities"][0]
+    false_copy = enriched["activities"][0]["if_false_activities"][0]
+    assert "input_dataset_definitions" in true_copy
+    assert "input_dataset_definitions" in false_copy
+
+
+def test_normalize_type_properties_recurses_into_nested_activities() -> None:
+    """type_properties of nested activities inside ForEach should be flattened."""
+    activity = {
+        "name": "loop",
+        "type": "ForEach",
+        "type_properties": {
+            "items": {"value": "@array(['x'])"},
+            "activities": [
+                {
+                    "name": "inner_copy",
+                    "type": "Copy",
+                    "type_properties": {
+                        "source": {"type": "ParquetSource"},
+                        "sink": {"type": "ParquetSink"},
+                    },
+                }
+            ],
+        },
+    }
+    normalized = _normalize_activity_type_properties(activity)
+    inner = normalized["activities"][0]
+    assert "source" in inner, "Nested activity type_properties should be flattened"
+    assert "sink" in inner, "Nested activity type_properties should be flattened"
+    assert "type_properties" not in inner


### PR DESCRIPTION
## Summary

- **FactoryDefinitionStore** now calls `normalize_arm_pipeline()` to flatten `type_properties` for activities from the ADF API — matching what `JsonDefinitionStore` already does
- **File dataset path parsing** (`parse_abfs_file_path`, `parse_cloud_file_path`) no longer requires `file_name` when `folder_path` is present — supports directory-level and wildcard reads
- **PipelineAdapter** recursively enriches nested activities inside ForEach/IfCondition with dataset and linked-service metadata