### PR TITLE
Add profiler package for ADF migration readiness assessment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     "types-pyyaml>=6.0.12.20250915,<7",
     "pydoc-markdown>=4.8.2,<5",
 ]
+profiler = [
+    "azure-identity>=1.16.1,<2",
+    "azure-mgmt-datafactory>=9.0.0,<10",
+]
 
 [build-system]
 requires = ["hatchling==1.29.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,6 @@ dev = [
     "types-pyyaml>=6.0.12.20250915,<7",
     "pydoc-markdown>=4.8.2,<5",
 ]
-profiler = [
-    "azure-identity>=1.16.1,<2",
-    "azure-mgmt-datafactory>=9.0.0,<10",
-]
 
 [build-system]
 requires = ["hatchling==1.29.0"]

--- a/src/wkmigrate/clients/factory_client.py
+++ b/src/wkmigrate/clients/factory_client.py
@@ -54,18 +54,29 @@ class FactoryClient:
         )
         self.management_client = DataFactoryManagementClient(credential, self.subscription_id)
 
-    def list_pipelines(self) -> list[str]:
+    def list_pipelines(self, include_metadata: bool = False) -> list[str] | list[dict]:
         """
-        Lists the names of all pipelines available in the Data Factory.
+        Lists pipelines available in the Data Factory.
+
+        When ``include_metadata`` is *False* (the default) only pipeline names
+        are returned, preserving backward compatibility.  When *True*, full
+        pipeline definitions are returned as dictionaries.
+
+        Args:
+            include_metadata: If ``True``, return full pipeline dicts instead
+                of name strings.
 
         Returns:
-            Pipeline names as a ``list[str]``.
+            Pipeline names as ``list[str]`` or full definitions as
+            ``list[dict]``.
         """
         if self.management_client is None:
             raise ValueError("management_client is not initialized")
         pipelines = self.management_client.pipelines.list_by_factory(
             resource_group_name=self.resource_group_name, factory_name=self.factory_name
         )
+        if include_metadata:
+            return [dict(pipeline.as_dict()) for pipeline in pipelines]
         return [pipeline.name for pipeline in pipelines if pipeline.name is not None]  # type: ignore[misc]
 
     def get_pipeline(self, pipeline_name: str) -> dict:
@@ -116,7 +127,7 @@ class FactoryClient:
         Returns:
             Trigger definition as a ``dict``, or ``None`` if the pipeline has no trigger.
         """
-        triggers = self._list_triggers()
+        triggers = self.list_triggers()
         for trigger in triggers:
             properties = trigger.get("properties")
             if properties is None:
@@ -139,7 +150,7 @@ class FactoryClient:
                 return trigger
         return None
 
-    def _list_triggers(self) -> list[dict]:
+    def list_triggers(self) -> list[dict]:
         """
         Lists triggers available in the source Data Factory.
 
@@ -165,7 +176,7 @@ class FactoryClient:
         Returns:
             Dataset definition as a ``dict``.
         """
-        datasets = self._list_datasets()
+        datasets = self.list_datasets()
         for dataset in datasets:
             if dataset.get("name") != dataset_name:
                 continue
@@ -181,7 +192,7 @@ class FactoryClient:
             return dataset
         raise ValueError(f'No dataset found for factory with name "{dataset_name}"')
 
-    def _list_datasets(self) -> list[dict]:
+    def list_datasets(self) -> list[dict]:
         """
         Lists dataset definitions available in the source Data Factory.
 
@@ -196,3 +207,31 @@ class FactoryClient:
         if datasets is None:
             raise ValueError(f'No datasets found for factory "{self.factory_name}"')
         return [dict(dataset.as_dict()) for dataset in datasets]
+
+    def list_linked_services(self) -> list[dict]:
+        """
+        Lists all linked-service definitions available in the Data Factory.
+
+        Returns:
+            Linked-service definitions as a ``list[dict]``.
+        """
+        if self.management_client is None:
+            raise ValueError("management_client is not initialized")
+        linked_services = self.management_client.linked_services.list_by_factory(
+            resource_group_name=self.resource_group_name, factory_name=self.factory_name
+        )
+        return [dict(ls.as_dict()) for ls in linked_services]
+
+    def list_integration_runtimes(self) -> list[dict]:
+        """
+        Lists all integration-runtime definitions available in the Data Factory.
+
+        Returns:
+            Integration-runtime definitions as a ``list[dict]``.
+        """
+        if self.management_client is None:
+            raise ValueError("management_client is not initialized")
+        runtimes = self.management_client.integration_runtimes.list_by_factory(
+            resource_group_name=self.resource_group_name, factory_name=self.factory_name
+        )
+        return [dict(ir.as_dict()) for ir in runtimes]

--- a/src/wkmigrate/clients/factory_client.py
+++ b/src/wkmigrate/clients/factory_client.py
@@ -54,30 +54,37 @@ class FactoryClient:
         )
         self.management_client = DataFactoryManagementClient(credential, self.subscription_id)
 
-    def list_pipelines(self, include_metadata: bool = False) -> list[str] | list[dict]:
+    def list_pipelines(self) -> list[str]:
         """
-        Lists pipelines available in the Data Factory.
-
-        When ``include_metadata`` is *False* (the default) only pipeline names
-        are returned, preserving backward compatibility.  When *True*, full
-        pipeline definitions are returned as dictionaries.
-
-        Args:
-            include_metadata: If ``True``, return full pipeline dicts instead
-                of name strings.
+        Lists the names of all pipelines available in the Data Factory.
 
         Returns:
-            Pipeline names as ``list[str]`` or full definitions as
-            ``list[dict]``.
+            Pipeline names as a ``list[str]``.
         """
         if self.management_client is None:
             raise ValueError("management_client is not initialized")
         pipelines = self.management_client.pipelines.list_by_factory(
             resource_group_name=self.resource_group_name, factory_name=self.factory_name
         )
-        if include_metadata:
-            return [dict(pipeline.as_dict()) for pipeline in pipelines]
         return [pipeline.name for pipeline in pipelines if pipeline.name is not None]  # type: ignore[misc]
+
+    def list_pipeline_definitions(self) -> list[dict]:
+        """
+        Lists full pipeline definitions available in the Data Factory.
+
+        Unlike ``list_pipelines``, which returns only names, this method returns
+        the complete pipeline definition dictionaries including activities,
+        parameters, and other metadata.
+
+        Returns:
+            Pipeline definitions as a ``list[dict]``.
+        """
+        if self.management_client is None:
+            raise ValueError("management_client is not initialized")
+        pipelines = self.management_client.pipelines.list_by_factory(
+            resource_group_name=self.resource_group_name, factory_name=self.factory_name
+        )
+        return [dict(pipeline.as_dict()) for pipeline in pipelines]
 
     def get_pipeline(self, pipeline_name: str) -> dict:
         """

--- a/src/wkmigrate/profiler/__init__.py
+++ b/src/wkmigrate/profiler/__init__.py
@@ -7,11 +7,13 @@ from wkmigrate.profiler.profile import (
     ObjectCount,
 )
 from wkmigrate.profiler.profiler import (
+    format_profile,
+    profile_factory,
+)
+from wkmigrate.supported_types import (
     SUPPORTED_ACTIVITY_TYPES,
     SUPPORTED_DATASET_TYPES,
     SUPPORTED_LINKED_SERVICE_TYPES,
-    format_profile,
-    profile_factory,
 )
 
 __all__ = [

--- a/src/wkmigrate/profiler/__init__.py
+++ b/src/wkmigrate/profiler/__init__.py
@@ -1,0 +1,27 @@
+"""Profiler package for assessing Azure Data Factory migration readiness."""
+
+from wkmigrate.profiler.profile import (
+    DatasetDetail,
+    FactoryProfile,
+    IntegrationRuntimeDetail,
+    ObjectCount,
+)
+from wkmigrate.profiler.profiler import (
+    SUPPORTED_ACTIVITY_TYPES,
+    SUPPORTED_DATASET_TYPES,
+    SUPPORTED_LINKED_SERVICE_TYPES,
+    format_profile,
+    profile_factory,
+)
+
+__all__ = [
+    "DatasetDetail",
+    "FactoryProfile",
+    "IntegrationRuntimeDetail",
+    "ObjectCount",
+    "SUPPORTED_ACTIVITY_TYPES",
+    "SUPPORTED_DATASET_TYPES",
+    "SUPPORTED_LINKED_SERVICE_TYPES",
+    "format_profile",
+    "profile_factory",
+]

--- a/src/wkmigrate/profiler/profile.py
+++ b/src/wkmigrate/profiler/profile.py
@@ -1,0 +1,50 @@
+"""Data models for Azure Data Factory profiling results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class ObjectCount:
+    """Counts of total, supported, and unsupported objects."""
+
+    total: int
+    supported: int
+    unsupported: int
+
+
+@dataclass(slots=True)
+class DatasetDetail:
+    """Detail record for a single dataset."""
+
+    dataset_name: str
+    dataset_type: str
+    linked_service_name: str | None
+    linked_service_type: str | None
+
+
+@dataclass(slots=True)
+class IntegrationRuntimeDetail:
+    """Detail record for a single integration runtime."""
+
+    name: str
+    runtime_type: str
+    node_count: int | None = None
+
+
+@dataclass(slots=True)
+class FactoryProfile:
+    """Complete profile of an Azure Data Factory resource."""
+
+    factory_name: str
+    pipelines: ObjectCount
+    activities: ObjectCount
+    linked_services: ObjectCount
+    datasets: ObjectCount
+    triggers: ObjectCount
+    integration_runtimes: ObjectCount
+    dataset_details: list[DatasetDetail] = field(default_factory=list)
+    integration_runtime_details: list[IntegrationRuntimeDetail] = field(default_factory=list)
+    unsupported_activity_types: list[str] = field(default_factory=list)
+    unsupported_dataset_types: list[str] = field(default_factory=list)

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import logging
+
+# Import translator dispatchers first so every @translates_activity /
+# @translates_dataset decorator fires before we read the sets.
+import wkmigrate.translators.activity_translators.activity_translator as _activity_reg  # noqa: F401
+import wkmigrate.translators.dataset_translators.dataset_translator as _dataset_reg  # noqa: F401
 from wkmigrate.clients.factory_client import FactoryClient
 from wkmigrate.profiler.profile import (
     DatasetDetail,

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -1,6 +1,7 @@
 """Profile an Azure Data Factory resource to assess migration readiness."""
 
 from __future__ import annotations
+
 import logging
 
 from wkmigrate.clients.factory_client import FactoryClient
@@ -10,46 +11,13 @@ from wkmigrate.profiler.profile import (
     IntegrationRuntimeDetail,
     ObjectCount,
 )
+from wkmigrate.supported_types import (
+    SUPPORTED_ACTIVITY_TYPES,
+    SUPPORTED_DATASET_TYPES,
+    SUPPORTED_LINKED_SERVICE_TYPES,
+)
 
 logger = logging.getLogger(__name__)
-
-SUPPORTED_ACTIVITY_TYPES = {
-    "Copy",
-    "DatabricksJob",
-    "DatabricksNotebook",
-    "DatabricksSparkJar",
-    "DatabricksSparkPython",
-    "ForEach",
-    "IfCondition",
-    "Lookup",
-    "SetVariable",
-    "WebActivity",
-}
-
-SUPPORTED_DATASET_TYPES = {
-    "Avro",
-    "DelimitedText",
-    "Json",
-    "Orc",
-    "Parquet",
-    "AzureSqlTable",
-    "AzurePostgreSqlTable",
-    "AzureMySqlTable",
-    "OracleTable",
-    "AzureDatabricksDeltaLakeDataset",
-}
-
-SUPPORTED_LINKED_SERVICE_TYPES = {
-    "AzureBlobFS",
-    "AzureBlobStorage",
-    "AzureSqlDatabase",
-    "AzureDatabricks",
-    "AmazonS3",
-    "GoogleCloudStorage",
-    "AzurePostgreSql",
-    "AzureMySql",
-    "Oracle",
-}
 
 
 def profile_factory(client: FactoryClient) -> FactoryProfile:
@@ -61,7 +29,7 @@ def profile_factory(client: FactoryClient) -> FactoryProfile:
     Returns:
         A ``FactoryProfile`` summarising the factory contents.
     """
-    pipelines = client.list_pipelines(include_metadata=True)
+    pipelines = client.list_pipeline_definitions()
     datasets = client.list_datasets()
     linked_services = client.list_linked_services()
     triggers = client.list_triggers()

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -1,0 +1,272 @@
+"""Profile an Azure Data Factory resource to assess migration readiness."""
+
+from __future__ import annotations
+import logging
+
+from wkmigrate.clients.factory_client import FactoryClient
+from wkmigrate.profiler.profile import (
+    DatasetDetail,
+    FactoryProfile,
+    IntegrationRuntimeDetail,
+    ObjectCount,
+)
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_ACTIVITY_TYPES = {
+    "Copy",
+    "DatabricksJob",
+    "DatabricksNotebook",
+    "DatabricksSparkJar",
+    "DatabricksSparkPython",
+    "ForEach",
+    "IfCondition",
+    "Lookup",
+    "SetVariable",
+    "WebActivity",
+}
+
+SUPPORTED_DATASET_TYPES = {
+    "Avro",
+    "DelimitedText",
+    "Json",
+    "Orc",
+    "Parquet",
+    "AzureSqlTable",
+    "AzurePostgreSqlTable",
+    "AzureMySqlTable",
+    "OracleTable",
+    "AzureDatabricksDeltaLakeDataset",
+}
+
+SUPPORTED_LINKED_SERVICE_TYPES = {
+    "AzureBlobFS",
+    "AzureBlobStorage",
+    "AzureSqlDatabase",
+    "AzureDatabricks",
+    "AmazonS3",
+    "GoogleCloudStorage",
+    "AzurePostgreSql",
+    "AzureMySql",
+    "Oracle",
+}
+
+
+def profile_factory(client: FactoryClient) -> FactoryProfile:
+    """Profile an Azure Data Factory resource.
+
+    Args:
+        client: Authenticated ``FactoryClient`` for the target factory.
+
+    Returns:
+        A ``FactoryProfile`` summarising the factory contents.
+    """
+    pipelines = client.list_pipelines(include_metadata=True)
+    datasets = client.list_datasets()
+    linked_services = client.list_linked_services()
+    triggers = client.list_triggers()
+    integration_runtimes = client.list_integration_runtimes()
+
+    activity_counts, unsupported_activity_types = _count_activities(pipelines)
+    dataset_counts, dataset_details, unsupported_dataset_types = _count_datasets(datasets, linked_services)
+    ls_counts = _count_linked_services(linked_services)
+    ir_counts, ir_details = _build_integration_runtime_details(integration_runtimes)
+
+    return FactoryProfile(
+        factory_name=client.factory_name,
+        pipelines=ObjectCount(len(pipelines), len(pipelines), 0),
+        activities=activity_counts,
+        linked_services=ls_counts,
+        datasets=dataset_counts,
+        triggers=ObjectCount(len(triggers), len(triggers), 0),
+        integration_runtimes=ir_counts,
+        dataset_details=dataset_details,
+        integration_runtime_details=ir_details,
+        unsupported_activity_types=unsupported_activity_types,
+        unsupported_dataset_types=unsupported_dataset_types,
+    )
+
+
+def format_profile(profile: FactoryProfile) -> str:
+    """Format a FactoryProfile as human-readable text.
+
+    Args:
+        profile: The factory profile to format.
+
+    Returns:
+        Formatted multi-line string.
+    """
+    lines = [
+        f"Azure Data Factory Profile: {profile.factory_name}",
+        "=" * 60,
+        "",
+        "Object Counts:",
+        f"  Pipelines:            {profile.pipelines.total}",
+        f"  Activities:           {profile.activities.total}"
+        f" ({profile.activities.supported} supported, {profile.activities.unsupported} unsupported)",
+        f"  Linked Services:      {profile.linked_services.total}"
+        f" ({profile.linked_services.supported} supported, {profile.linked_services.unsupported} unsupported)",
+        f"  Datasets:             {profile.datasets.total}"
+        f" ({profile.datasets.supported} supported, {profile.datasets.unsupported} unsupported)",
+        f"  Triggers:             {profile.triggers.total}",
+        f"  Integration Runtimes: {profile.integration_runtimes.total}",
+    ]
+
+    if profile.unsupported_activity_types:
+        lines += ["", "Unsupported Activity Types:"]
+        for activity_type in profile.unsupported_activity_types:
+            lines.append(f"  - {activity_type}")
+
+    if profile.unsupported_dataset_types:
+        lines += ["", "Unsupported Dataset Types:"]
+        for dataset_type in profile.unsupported_dataset_types:
+            lines.append(f"  - {dataset_type}")
+
+    if profile.dataset_details:
+        lines += ["", "Dataset Details:"]
+        for detail in profile.dataset_details:
+            ls_name = detail.linked_service_name or "N/A"
+            ls_type = detail.linked_service_type or "N/A"
+            lines.append(f"  - {detail.dataset_name} ({detail.dataset_type}) via {ls_name} [{ls_type}]")
+
+    if profile.integration_runtime_details:
+        lines += ["", "Integration Runtimes:"]
+        for irt in profile.integration_runtime_details:
+            node_info = f", {irt.node_count} nodes" if irt.node_count is not None else ""
+            lines.append(f"  - {irt.name} ({irt.runtime_type}{node_info})")
+
+    return "\n".join(lines)
+
+
+def _count_activities(pipelines: list) -> tuple[ObjectCount, list[str]]:
+    """Walk nested activities, classify supported/unsupported.
+
+    Returns:
+        A tuple of ``(ObjectCount, unsupported_type_names)``.
+    """
+    all_activities: list[dict] = []
+    for pipeline in pipelines:
+        if not isinstance(pipeline, dict):
+            logger.warning("Skipping non-dictionary pipeline")
+            continue
+        _collect_activities(pipeline.get("activities") or [], all_activities)
+
+    supported = 0
+    unsupported_types: set[str] = set()
+    for activity in all_activities:
+        activity_type = activity.get("type") or "Unknown"
+        if activity_type in SUPPORTED_ACTIVITY_TYPES:
+            supported += 1
+        else:
+            unsupported_types.add(activity_type)
+
+    total = len(all_activities)
+    return ObjectCount(total, supported, total - supported), sorted(unsupported_types)
+
+
+def _count_datasets(
+    datasets: list[dict],
+    linked_services: list[dict],
+) -> tuple[ObjectCount, list[DatasetDetail], list[str]]:
+    """Classify datasets, build details.
+
+    Returns:
+        A tuple of ``(ObjectCount, dataset_details, unsupported_type_names)``.
+    """
+    ls_type_map = _build_linked_service_type_map(linked_services)
+
+    supported = 0
+    unsupported = 0
+    unsupported_types: set[str] = set()
+    details: list[DatasetDetail] = []
+
+    for dset in datasets:
+        props = dset.get("properties", {})
+        ds_type = props.get("type") or "Unknown"
+        ls_ref = props.get("linked_service_name", {})
+        ls_name = ls_ref.get("reference_name") if isinstance(ls_ref, dict) else None
+        ls_type = ls_type_map.get(ls_name) if ls_name else None
+
+        details.append(
+            DatasetDetail(
+                dataset_name=dset.get("name", "Unknown"),
+                dataset_type=ds_type,
+                linked_service_name=ls_name,
+                linked_service_type=ls_type,
+            )
+        )
+
+        if ds_type in SUPPORTED_DATASET_TYPES:
+            supported += 1
+        else:
+            unsupported += 1
+            unsupported_types.add(ds_type)
+
+    total = supported + unsupported
+    return ObjectCount(total, supported, unsupported), details, sorted(unsupported_types)
+
+
+def _count_linked_services(linked_services: list[dict]) -> ObjectCount:
+    """Count supported vs unsupported linked services."""
+    supported = sum(
+        1 for ls in linked_services if ls.get("properties", {}).get("type") in SUPPORTED_LINKED_SERVICE_TYPES
+    )
+    total = len(linked_services)
+    return ObjectCount(total, supported, total - supported)
+
+
+def _build_integration_runtime_details(
+    integration_runtimes: list[dict],
+) -> tuple[ObjectCount, list[IntegrationRuntimeDetail]]:
+    """Build integration runtime details and counts.
+
+    Returns:
+        A tuple of ``(ObjectCount, ir_details)``.
+    """
+    details: list[IntegrationRuntimeDetail] = []
+    for irt in integration_runtimes:
+        props = irt.get("properties", {})
+        node_count = None
+        if props.get("type") == "SelfHosted":
+            node_count = props.get("type_properties", {}).get("compute_properties", {}).get("number_of_nodes")
+        details.append(
+            IntegrationRuntimeDetail(
+                name=irt.get("name", "Unknown"),
+                runtime_type=props.get("type", "Unknown"),
+                node_count=node_count,
+            )
+        )
+    total = len(integration_runtimes)
+    return ObjectCount(total, total, 0), details
+
+
+def _collect_activities(activities: list[dict] | None, result: list[dict]) -> None:
+    """Recursively collect all activities including nested ones.
+
+    Args:
+        activities: List of activity dicts to process, or ``None``.
+        result: Accumulator list where discovered activities are appended.
+    """
+    for activity in activities or []:
+        result.append(activity)
+        # ForEach inner activities
+        inner = activity.get("activities") or []
+        if inner:
+            _collect_activities(inner, result)
+        # IfCondition branches
+        for branch_key in ("if_true_activities", "if_false_activities"):
+            branch = activity.get(branch_key) or []
+            if branch:
+                _collect_activities(branch, result)
+
+
+def _build_linked_service_type_map(linked_services: list[dict]) -> dict[str, str | None]:
+    """Build a name -> type lookup for linked services.
+
+    Args:
+        linked_services: Full list of linked service dicts.
+
+    Returns:
+        Mapping from linked service name to its type string.
+    """
+    return {ls.get("name", ""): ls.get("properties", {}).get("type") for ls in linked_services}

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-
 from wkmigrate.clients.factory_client import FactoryClient
 from wkmigrate.profiler.profile import (
     DatasetDetail,

--- a/src/wkmigrate/supported_types.py
+++ b/src/wkmigrate/supported_types.py
@@ -1,0 +1,50 @@
+"""Canonical sets of ADF object types that wkmigrate can translate.
+
+These constants are the single source of truth shared by translators and
+the profiler. When translator support is added for a new ADF type, it
+should be registered here so the profiler stays in sync automatically.
+"""
+
+SUPPORTED_ACTIVITY_TYPES: frozenset[str] = frozenset(
+    {
+        "Copy",
+        "DatabricksJob",
+        "DatabricksNotebook",
+        "DatabricksSparkJar",
+        "DatabricksSparkPython",
+        "ForEach",
+        "IfCondition",
+        "Lookup",
+        "SetVariable",
+        "WebActivity",
+    }
+)
+
+SUPPORTED_DATASET_TYPES: frozenset[str] = frozenset(
+    {
+        "Avro",
+        "DelimitedText",
+        "Json",
+        "Orc",
+        "Parquet",
+        "AzureSqlTable",
+        "AzurePostgreSqlTable",
+        "AzureMySqlTable",
+        "OracleTable",
+        "AzureDatabricksDeltaLakeDataset",
+    }
+)
+
+SUPPORTED_LINKED_SERVICE_TYPES: frozenset[str] = frozenset(
+    {
+        "AzureBlobFS",
+        "AzureBlobStorage",
+        "AzureSqlDatabase",
+        "AzureDatabricks",
+        "AmazonS3",
+        "GoogleCloudStorage",
+        "AzurePostgreSql",
+        "AzureMySql",
+        "Oracle",
+    }
+)

--- a/src/wkmigrate/supported_types.py
+++ b/src/wkmigrate/supported_types.py
@@ -1,39 +1,22 @@
 """Canonical sets of ADF object types that wkmigrate can translate.
 
-These constants are the single source of truth shared by translators and
-the profiler. When translator support is added for a new ADF type, it
-should be registered here so the profiler stays in sync automatically.
+Translator modules register themselves at import time using the
+``translates_activity`` and ``translates_dataset`` decorators. The
+resulting sets are the single source of truth consumed by the profiler.
+
+Linked-service types have no translator dispatch, so they are listed
+explicitly.
 """
 
-SUPPORTED_ACTIVITY_TYPES: frozenset[str] = frozenset(
-    {
-        "Copy",
-        "DatabricksJob",
-        "DatabricksNotebook",
-        "DatabricksSparkJar",
-        "DatabricksSparkPython",
-        "ForEach",
-        "IfCondition",
-        "Lookup",
-        "SetVariable",
-        "WebActivity",
-    }
-)
+from __future__ import annotations
 
-SUPPORTED_DATASET_TYPES: frozenset[str] = frozenset(
-    {
-        "Avro",
-        "DelimitedText",
-        "Json",
-        "Orc",
-        "Parquet",
-        "AzureSqlTable",
-        "AzurePostgreSqlTable",
-        "AzureMySqlTable",
-        "OracleTable",
-        "AzureDatabricksDeltaLakeDataset",
-    }
-)
+from collections.abc import Callable
+from typing import TypeVar
+
+_F = TypeVar("_F", bound=Callable)
+
+SUPPORTED_ACTIVITY_TYPES: set[str] = set()
+SUPPORTED_DATASET_TYPES: set[str] = set()
 
 SUPPORTED_LINKED_SERVICE_TYPES: frozenset[str] = frozenset(
     {
@@ -48,3 +31,45 @@ SUPPORTED_LINKED_SERVICE_TYPES: frozenset[str] = frozenset(
         "Oracle",
     }
 )
+
+
+def translates_activity(*adf_type_names: str) -> Callable[[_F], _F]:
+    """Register one or more ADF activity type names as supported.
+
+    Use as a decorator on the top-level translator function::
+
+        @translates_activity("Copy")
+        def translate_copy_activity(...): ...
+    """
+
+    def decorator(func: _F) -> _F:
+        SUPPORTED_ACTIVITY_TYPES.update(adf_type_names)
+        return func
+
+    return decorator
+
+
+def translates_dataset(*adf_type_names: str) -> Callable[[_F], _F]:
+    """Register one or more ADF dataset type names as supported.
+
+    Use as a decorator on the top-level translator function::
+
+        @translates_dataset("Avro", "DelimitedText")
+        def translate_file_dataset(...): ...
+    """
+
+    def decorator(func: _F) -> _F:
+        SUPPORTED_DATASET_TYPES.update(adf_type_names)
+        return func
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Trigger translator imports so every decorator fires at module-load time.
+# The decorators (above) are already defined, so the circular reference
+# through each translator's ``from wkmigrate.supported_types import ...``
+# resolves safely against this partially-initialised module.
+# ---------------------------------------------------------------------------
+import wkmigrate.translators.activity_translators.activity_translator as _activity_reg  # noqa: E402,F401
+import wkmigrate.translators.dataset_translators.dataset_translator as _dataset_reg  # noqa: E402,F401

--- a/src/wkmigrate/supported_types.py
+++ b/src/wkmigrate/supported_types.py
@@ -63,13 +63,3 @@ def translates_dataset(*adf_type_names: str) -> Callable[[_F], _F]:
         return func
 
     return decorator
-
-
-# ---------------------------------------------------------------------------
-# Trigger translator imports so every decorator fires at module-load time.
-# The decorators (above) are already defined, so the circular reference
-# through each translator's ``from wkmigrate.supported_types import ...``
-# resolves safely against this partially-initialised module.
-# ---------------------------------------------------------------------------
-import wkmigrate.translators.activity_translators.activity_translator as _activity_reg  # noqa: E402,F401
-import wkmigrate.translators.dataset_translators.dataset_translator as _dataset_reg  # noqa: E402,F401

--- a/src/wkmigrate/translators/activity_translators/copy_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/copy_activity_translator.py
@@ -9,6 +9,7 @@ unparsable inputs.
 from wkmigrate.models.ir.pipeline import ColumnMapping, CopyActivity
 from wkmigrate.models.ir.datasets import Dataset
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 from wkmigrate.utils import (
     get_data_source_definition,
     get_data_source_properties,
@@ -17,6 +18,7 @@ from wkmigrate.utils import (
 )
 
 
+@translates_activity("Copy")
 def translate_copy_activity(activity: dict, base_kwargs: dict) -> CopyActivity | UnsupportedValue:
     """
     Translates an ADF Copy activity into a ``CopyActivity`` object. Copy activities are translated

--- a/src/wkmigrate/translators/activity_translators/databricks_job_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/databricks_job_activity_translator.py
@@ -7,9 +7,11 @@ objects for any unparsable inputs.
 
 from wkmigrate.models.ir.pipeline import RunJobActivity
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 from wkmigrate.utils import parse_mapping
 
 
+@translates_activity("DatabricksJob")
 def translate_databricks_job_activity(activity: dict, base_kwargs: dict) -> RunJobActivity | UnsupportedValue:
     """
     Translates an ADF Databricks Job activity into a ``RunJobActivity`` object.

--- a/src/wkmigrate/translators/activity_translators/for_each_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/for_each_activity_translator.py
@@ -16,8 +16,10 @@ from wkmigrate.models.ir.pipeline import Activity, ForEachActivity, Pipeline, Ru
 from wkmigrate.models.ir.translation_context import TranslationContext
 from wkmigrate.models.ir.translator_result import TranslationResult
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 
 
+@translates_activity("ForEach")
 def translate_for_each_activity(
     activity: dict,
     base_kwargs: dict,

--- a/src/wkmigrate/translators/activity_translators/if_condition_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/if_condition_activity_translator.py
@@ -16,8 +16,10 @@ from wkmigrate.models.ir.pipeline import Activity, IfConditionActivity
 from wkmigrate.models.ir.translation_context import TranslationContext
 from wkmigrate.models.ir.translator_result import TranslationResult
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 
 
+@translates_activity("IfCondition")
 def translate_if_condition_activity(
     activity: dict,
     base_kwargs: dict,

--- a/src/wkmigrate/translators/activity_translators/lookup_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/lookup_activity_translator.py
@@ -10,6 +10,7 @@ properties, and emit ``UnsupportedValue`` objects for any unparsable inputs.
 from wkmigrate.models.ir.pipeline import LookupActivity
 from wkmigrate.models.ir.datasets import Dataset
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 from wkmigrate.utils import (
     get_data_source_definition,
     get_data_source_properties,
@@ -18,6 +19,7 @@ from wkmigrate.utils import (
 )
 
 
+@translates_activity("Lookup")
 def translate_lookup_activity(activity: dict, base_kwargs: dict) -> LookupActivity | UnsupportedValue:
     """
     Translates an ADF Lookup activity into a ``LookupActivity`` object.

--- a/src/wkmigrate/translators/activity_translators/notebook_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/notebook_activity_translator.py
@@ -9,8 +9,10 @@ import warnings
 from wkmigrate.models.ir.pipeline import DatabricksNotebookActivity
 from wkmigrate.models.ir.unsupported import UnsupportedValue
 from wkmigrate.not_translatable import NotTranslatableWarning
+from wkmigrate.supported_types import translates_activity
 
 
+@translates_activity("DatabricksNotebook")
 def translate_notebook_activity(activity: dict, base_kwargs: dict) -> DatabricksNotebookActivity | UnsupportedValue:
     """
     Translates an ADF Databricks Notebook activity into a ``DatabricksNotebookActivity`` object.

--- a/src/wkmigrate/translators/activity_translators/set_variable_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/set_variable_activity_translator.py
@@ -15,8 +15,10 @@ from wkmigrate.models.ir.pipeline import SetVariableActivity
 from wkmigrate.models.ir.translation_context import TranslationContext
 from wkmigrate.models.ir.unsupported import UnsupportedValue
 from wkmigrate.parsers.expression_parsers import parse_variable_value
+from wkmigrate.supported_types import translates_activity
 
 
+@translates_activity("SetVariable")
 def translate_set_variable_activity(
     activity: dict, base_kwargs: dict, context: TranslationContext | None = None
 ) -> tuple[SetVariableActivity | UnsupportedValue, TranslationContext]:

--- a/src/wkmigrate/translators/activity_translators/spark_jar_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/spark_jar_activity_translator.py
@@ -7,8 +7,10 @@ and emit ``UnsupportedValue`` objects for any unparsable inputs.
 
 from wkmigrate.models.ir.pipeline import SparkJarActivity
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 
 
+@translates_activity("DatabricksSparkJar")
 def translate_spark_jar_activity(activity: dict, base_kwargs: dict) -> SparkJarActivity | UnsupportedValue:
     """
     Translates an ADF Databricks Spark JAR activity into a ``SparkJarActivity`` object.

--- a/src/wkmigrate/translators/activity_translators/spark_python_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/spark_python_activity_translator.py
@@ -7,8 +7,10 @@ and emit ``UnsupportedValue`` objects for any unparsable inputs.
 
 from wkmigrate.models.ir.pipeline import SparkPythonActivity
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 
 
+@translates_activity("DatabricksSparkPython")
 def translate_spark_python_activity(activity: dict, base_kwargs: dict) -> SparkPythonActivity | UnsupportedValue:
     """
     Translates an ADF Databricks Spark Python activity into a ``SparkPythonActivity`` object.

--- a/src/wkmigrate/translators/activity_translators/web_activity_translator.py
+++ b/src/wkmigrate/translators/activity_translators/web_activity_translator.py
@@ -8,9 +8,11 @@ objects for any unparsable inputs.
 
 from wkmigrate.models.ir.pipeline import WebActivity
 from wkmigrate.models.ir.unsupported import UnsupportedValue
+from wkmigrate.supported_types import translates_activity
 from wkmigrate.utils import parse_timeout_string, parse_authentication
 
 
+@translates_activity("WebActivity")
 def translate_web_activity(activity: dict, base_kwargs: dict) -> WebActivity | UnsupportedValue:
     """
     Translates an ADF Web activity into a ``WebActivity`` object.

--- a/src/wkmigrate/translators/dataset_translators/delta_table_dataset_translator.py
+++ b/src/wkmigrate/translators/dataset_translators/delta_table_dataset_translator.py
@@ -7,9 +7,11 @@ objects, parsing Databricks linked-service metadata and table properties.
 from wkmigrate.models.ir.datasets import DeltaTableDataset
 from wkmigrate.models.ir.unsupported import UnsupportedValue
 from wkmigrate.translators.dataset_translators.utils import get_linked_service_definition
+from wkmigrate.supported_types import translates_dataset
 from wkmigrate.translators.linked_service_translators import translate_databricks_cluster_spec
 
 
+@translates_dataset("AzureDatabricksDeltaLakeDataset")
 def translate_delta_table_dataset(dataset: dict) -> DeltaTableDataset | UnsupportedValue:
     """
     Translates a Delta table dataset definition into a ``DeltaTableDataset`` object.

--- a/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
+++ b/src/wkmigrate/translators/dataset_translators/file_dataset_translator.py
@@ -17,6 +17,7 @@ from wkmigrate.translators.dataset_translators.utils import (
     parse_cloud_file_path,
     parse_format_options,
 )
+from wkmigrate.supported_types import translates_dataset
 from wkmigrate.translators.linked_service_translators import (
     translate_abfs_spec,
     translate_azure_blob_spec,
@@ -31,6 +32,7 @@ _CLOUD_TRANSLATORS: dict[str, Callable] = {
 }
 
 
+@translates_dataset("Avro", "DelimitedText", "Json", "Orc", "Parquet")
 def translate_file_dataset(
     dataset_type: str, dataset: dict, provider_type: str | None = None
 ) -> FileDataset | UnsupportedValue:

--- a/src/wkmigrate/translators/dataset_translators/sql_dataset_translator.py
+++ b/src/wkmigrate/translators/dataset_translators/sql_dataset_translator.py
@@ -10,6 +10,7 @@ from wkmigrate.models.ir.datasets import SqlTableDataset
 from wkmigrate.models.ir.linked_services import SqlLinkedService
 from wkmigrate.models.ir.unsupported import UnsupportedValue
 from wkmigrate.translators.dataset_translators.utils import get_linked_service_definition
+from wkmigrate.supported_types import translates_dataset
 from wkmigrate.translators.linked_service_translators import (
     translate_mysql_spec,
     translate_oracle_spec,
@@ -18,6 +19,7 @@ from wkmigrate.translators.linked_service_translators import (
 )
 
 
+@translates_dataset("AzureSqlTable")
 def translate_sql_server_dataset(dataset: dict) -> SqlTableDataset | UnsupportedValue:
     """
     Translates a SQL Server dataset definition into a ``SqlTableDataset`` object.
@@ -33,6 +35,7 @@ def translate_sql_server_dataset(dataset: dict) -> SqlTableDataset | Unsupported
     return _translate_sql_dataset(dataset, "sqlserver", translate_sql_server_spec, table, schema)
 
 
+@translates_dataset("AzurePostgreSqlTable")
 def translate_postgresql_dataset(dataset: dict) -> SqlTableDataset | UnsupportedValue:
     """
     Translates an Azure Database for PostgreSQL dataset definition into a ``SqlTableDataset`` object.
@@ -48,6 +51,7 @@ def translate_postgresql_dataset(dataset: dict) -> SqlTableDataset | Unsupported
     return _translate_sql_dataset(dataset, "postgresql", translate_postgresql_spec, table, schema)
 
 
+@translates_dataset("AzureMySqlTable")
 def translate_mysql_dataset(dataset: dict) -> SqlTableDataset | UnsupportedValue:
     """
     Translates an Azure Database for MySQL dataset definition into a ``SqlTableDataset`` object.
@@ -65,6 +69,7 @@ def translate_mysql_dataset(dataset: dict) -> SqlTableDataset | UnsupportedValue
     return _translate_sql_dataset(dataset, "mysql", translate_mysql_spec, table)
 
 
+@translates_dataset("OracleTable")
 def translate_oracle_dataset(dataset: dict) -> SqlTableDataset | UnsupportedValue:
     """
     Translates an Oracle Database dataset definition into a ``SqlTableDataset`` object.

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -1,0 +1,257 @@
+"""Unit tests for the profiler package."""
+
+from wkmigrate.profiler.profile import (
+    DatasetDetail,
+    FactoryProfile,
+    IntegrationRuntimeDetail,
+    ObjectCount,
+)
+from wkmigrate.profiler.profiler import (
+    _collect_activities,
+    _count_activities,
+    _count_datasets,
+    _count_linked_services,
+    _build_integration_runtime_details,
+    format_profile,
+)
+
+
+# -- _collect_activities -------------------------------------------------------
+
+
+def test_collect_flat_activities():
+    activities = [{"type": "Copy", "name": "A"}, {"type": "Lookup", "name": "B"}]
+    result: list[dict] = []
+    _collect_activities(activities, result)
+    assert len(result) == 2
+
+
+def test_collect_nested_for_each():
+    activities = [
+        {
+            "type": "ForEach",
+            "name": "Loop",
+            "activities": [
+                {"type": "Copy", "name": "Inner1"},
+                {"type": "Lookup", "name": "Inner2"},
+            ],
+        }
+    ]
+    result: list[dict] = []
+    _collect_activities(activities, result)
+    assert len(result) == 3
+
+
+def test_collect_nested_if_condition_branches():
+    activities = [
+        {
+            "type": "IfCondition",
+            "name": "Branch",
+            "if_true_activities": [{"type": "Copy", "name": "TruePath"}],
+            "if_false_activities": [
+                {"type": "WebActivity", "name": "FalsePath"},
+                {"type": "ExecutePipeline", "name": "AlsoFalse"},
+            ],
+        }
+    ]
+    result: list[dict] = []
+    _collect_activities(activities, result)
+    # IfCondition itself + 1 true + 2 false = 4
+    assert len(result) == 4
+
+
+def test_collect_empty_and_none():
+    result: list[dict] = []
+    _collect_activities([], result)
+    assert result == []
+
+    _collect_activities(None, result)
+    assert result == []
+
+
+# -- _count_activities ---------------------------------------------------------
+
+
+def test_count_all_supported():
+    pipelines = [{"activities": [{"type": "Copy"}, {"type": "Lookup"}]}]
+    counts, unsupported = _count_activities(pipelines)
+    assert counts == ObjectCount(total=2, supported=2, unsupported=0)
+    assert unsupported == []
+
+
+def test_count_all_unsupported():
+    pipelines = [{"activities": [{"type": "ExecutePipeline"}, {"type": "AzureFunctionActivity"}]}]
+    counts, unsupported = _count_activities(pipelines)
+    assert counts == ObjectCount(total=2, supported=0, unsupported=2)
+    assert unsupported == ["AzureFunctionActivity", "ExecutePipeline"]
+
+
+def test_count_mixed():
+    pipelines = [
+        {
+            "activities": [
+                {"type": "Copy"},
+                {"type": "ExecutePipeline"},
+                {"type": "ForEach", "activities": [{"type": "DatabricksNotebook"}]},
+            ]
+        }
+    ]
+    counts, unsupported = _count_activities(pipelines)
+    # Copy + ExecutePipeline + ForEach + DatabricksNotebook = 4 total
+    assert counts.total == 4
+    assert counts.supported == 3  # Copy, ForEach, DatabricksNotebook
+    assert counts.unsupported == 1
+    assert unsupported == ["ExecutePipeline"]
+
+
+def test_count_activities_empty_pipeline():
+    pipelines = [{"activities": []}]
+    counts, unsupported = _count_activities(pipelines)
+    assert counts == ObjectCount(total=0, supported=0, unsupported=0)
+    assert unsupported == []
+
+
+def test_count_activities_skips_non_dict_pipelines():
+    pipelines = ["not_a_dict", {"activities": [{"type": "Copy"}]}]
+    counts, _ = _count_activities(pipelines)
+    assert counts.total == 1
+
+
+# -- _count_datasets -----------------------------------------------------------
+
+
+def test_count_datasets_supported():
+    datasets = [
+        {"name": "ds1", "properties": {"type": "Parquet", "linked_service_name": {"reference_name": "ls1"}}},
+        {"name": "ds2", "properties": {"type": "AzureSqlTable", "linked_service_name": {"reference_name": "ls2"}}},
+    ]
+    linked_services = [
+        {"name": "ls1", "properties": {"type": "AzureBlobFS"}},
+        {"name": "ls2", "properties": {"type": "AzureSqlDatabase"}},
+    ]
+    counts, details, unsupported = _count_datasets(datasets, linked_services)
+    assert counts == ObjectCount(total=2, supported=2, unsupported=0)
+    assert unsupported == []
+    assert details[0] == DatasetDetail("ds1", "Parquet", "ls1", "AzureBlobFS")
+    assert details[1] == DatasetDetail("ds2", "AzureSqlTable", "ls2", "AzureSqlDatabase")
+
+
+def test_count_datasets_unsupported():
+    datasets = [
+        {"name": "ds1", "properties": {"type": "SalesforceObject"}},
+    ]
+    counts, details, unsupported = _count_datasets(datasets, [])
+    assert counts == ObjectCount(total=1, supported=0, unsupported=1)
+    assert unsupported == ["SalesforceObject"]
+    assert details[0].linked_service_name is None
+
+
+def test_count_datasets_missing_type():
+    datasets = [{"name": "ds1", "properties": {}}]
+    counts, details, unsupported = _count_datasets(datasets, [])
+    assert counts.unsupported == 1
+    assert details[0].dataset_type == "Unknown"
+
+
+# -- _count_linked_services ----------------------------------------------------
+
+
+def test_count_linked_services_mixed():
+    linked_services = [
+        {"name": "ls1", "properties": {"type": "AzureBlobFS"}},
+        {"name": "ls2", "properties": {"type": "CosmosDb"}},
+        {"name": "ls3", "properties": {"type": "AzureDatabricks"}},
+    ]
+    counts = _count_linked_services(linked_services)
+    assert counts == ObjectCount(total=3, supported=2, unsupported=1)
+
+
+# -- _build_integration_runtime_details ----------------------------------------
+
+
+def test_integration_runtime_managed():
+    runtimes = [{"name": "ir-managed", "properties": {"type": "Managed"}}]
+    counts, details = _build_integration_runtime_details(runtimes)
+    assert counts == ObjectCount(total=1, supported=1, unsupported=0)
+    assert details == [IntegrationRuntimeDetail("ir-managed", "Managed", node_count=None)]
+
+
+def test_integration_runtime_self_hosted_with_nodes():
+    runtimes = [
+        {
+            "name": "ir-self",
+            "properties": {
+                "type": "SelfHosted",
+                "type_properties": {"compute_properties": {"number_of_nodes": 4}},
+            },
+        }
+    ]
+    _, details = _build_integration_runtime_details(runtimes)
+    assert details[0].node_count == 4
+
+
+# -- format_profile ------------------------------------------------------------
+
+
+def test_format_profile_basic():
+    profile = FactoryProfile(
+        factory_name="test-factory",
+        pipelines=ObjectCount(2, 2, 0),
+        activities=ObjectCount(5, 3, 2),
+        linked_services=ObjectCount(3, 2, 1),
+        datasets=ObjectCount(4, 3, 1),
+        triggers=ObjectCount(1, 1, 0),
+        integration_runtimes=ObjectCount(1, 1, 0),
+        unsupported_activity_types=["ExecutePipeline", "Wait"],
+        unsupported_dataset_types=["SalesforceObject"],
+    )
+    text = format_profile(profile)
+    assert "test-factory" in text
+    assert "3 supported, 2 unsupported" in text
+    assert "ExecutePipeline" in text
+    assert "Wait" in text
+    assert "SalesforceObject" in text
+
+
+def test_format_profile_no_unsupported():
+    profile = FactoryProfile(
+        factory_name="clean-factory",
+        pipelines=ObjectCount(1, 1, 0),
+        activities=ObjectCount(2, 2, 0),
+        linked_services=ObjectCount(1, 1, 0),
+        datasets=ObjectCount(1, 1, 0),
+        triggers=ObjectCount(0, 0, 0),
+        integration_runtimes=ObjectCount(0, 0, 0),
+    )
+    text = format_profile(profile)
+    assert "Unsupported" not in text
+
+
+def test_format_profile_dataset_details():
+    profile = FactoryProfile(
+        factory_name="f",
+        pipelines=ObjectCount(0, 0, 0),
+        activities=ObjectCount(0, 0, 0),
+        linked_services=ObjectCount(0, 0, 0),
+        datasets=ObjectCount(1, 1, 0),
+        triggers=ObjectCount(0, 0, 0),
+        integration_runtimes=ObjectCount(0, 0, 0),
+        dataset_details=[DatasetDetail("my_ds", "Parquet", "my_ls", "AzureBlobFS")],
+    )
+    text = format_profile(profile)
+    assert "my_ds (Parquet) via my_ls [AzureBlobFS]" in text
+
+
+def test_format_profile_integration_runtime_details():
+    profile = FactoryProfile(
+        factory_name="f",
+        pipelines=ObjectCount(0, 0, 0),
+        activities=ObjectCount(0, 0, 0),
+        linked_services=ObjectCount(0, 0, 0),
+        datasets=ObjectCount(0, 0, 0),
+        triggers=ObjectCount(0, 0, 0),
+        integration_runtimes=ObjectCount(1, 1, 0),
+        integration_runtime_details=[IntegrationRuntimeDetail("ir-self", "SelfHosted", node_count=4)],
+    )
+    text = format_profile(profile)
+    assert "ir-self (SelfHosted, 4 nodes)" in text


### PR DESCRIPTION
## Changes

- Add `src/wkmigrate/profiler/` package with data models (`profile.py`) and profiling logic (`profiler.py`) for assessing Azure Data Factory migration readiness
- Extend `FactoryClient` with public `list_pipelines(include_metadata=True)`, `list_datasets()`, `list_linked_services()`, `list_triggers()`, and `list_integration_runtimes()` methods (previously `_list_datasets` and `_list_triggers` were private)
- Add `profiler` dependency group to `pyproject.toml` for optional install (`uv sync --group profiler`)

The profiler inspects an ADF factory and reports:
- Pipeline, activity, dataset, linked service, trigger, and integration runtime counts
- Supported vs unsupported classification for activities, datasets, and linked services
- Detailed dataset-to-linked-service mapping
- Integration runtime type and node count details
- Human-readable formatted output via `format_profile()`

### Linked issues

Resolves #25

### Tests

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests