### PR TITLE
Profiler: accept ARM JSON without a client; add pipeline_details

### DIFF
--- a/src/wkmigrate/profiler/__init__.py
+++ b/src/wkmigrate/profiler/__init__.py
@@ -5,6 +5,7 @@ from wkmigrate.profiler.profile import (
     FactoryProfile,
     IntegrationRuntimeDetail,
     ObjectCount,
+    PipelineDetail,
 )
 from wkmigrate.profiler.profiler import (
     format_profile,
@@ -21,6 +22,7 @@ __all__ = [
     "FactoryProfile",
     "IntegrationRuntimeDetail",
     "ObjectCount",
+    "PipelineDetail",
     "SUPPORTED_ACTIVITY_TYPES",
     "SUPPORTED_DATASET_TYPES",
     "SUPPORTED_LINKED_SERVICE_TYPES",

--- a/src/wkmigrate/profiler/profile.py
+++ b/src/wkmigrate/profiler/profile.py
@@ -35,29 +35,12 @@ class IntegrationRuntimeDetail:
 
 @dataclass(slots=True)
 class PipelineDetail:
-    """Per-pipeline breakdown of translatability and referenced resources.
-
-    Helps users see *which* pipelines in a factory are most translatable by
-    wkmigrate.  The supported/unsupported splits on activities, datasets, and
-    linked services count only the resources this pipeline actually uses; the
-    five integer totals make it easy to skim the dependency surface (e.g. a
-    pipeline that pulls 12 datasets across 7 linked services and 2 self-hosted
-    integration runtimes will surface much higher friction than one that runs
-    against a single Delta dataset).
-    """
+    """Per-pipeline breakdown of translatability and referenced resources."""
 
     pipeline_name: str
-    # Activities physically inside this pipeline (including those nested in
-    # ForEach loops and IfCondition branches).
     activities: ObjectCount
-    # Datasets referenced by this pipeline's activities.
     datasets: ObjectCount
-    # Linked services referenced by this pipeline (directly or transitively
-    # through its datasets).
     linked_services: ObjectCount
-    # Total counts for the pipeline (mirrors ``.activities.total`` etc. plus
-    # adds the trigger / integration-runtime totals that aren't broken down by
-    # supported/unsupported).
     total_activities: int = 0
     total_datasets: int = 0
     total_linked_services: int = 0

--- a/src/wkmigrate/profiler/profile.py
+++ b/src/wkmigrate/profiler/profile.py
@@ -34,6 +34,38 @@ class IntegrationRuntimeDetail:
 
 
 @dataclass(slots=True)
+class PipelineDetail:
+    """Per-pipeline breakdown of translatability and referenced resources.
+
+    Helps users see *which* pipelines in a factory are most translatable by
+    wkmigrate.  The supported/unsupported splits on activities, datasets, and
+    linked services count only the resources this pipeline actually uses; the
+    five integer totals make it easy to skim the dependency surface (e.g. a
+    pipeline that pulls 12 datasets across 7 linked services and 2 self-hosted
+    integration runtimes will surface much higher friction than one that runs
+    against a single Delta dataset).
+    """
+
+    pipeline_name: str
+    # Activities physically inside this pipeline (including those nested in
+    # ForEach loops and IfCondition branches).
+    activities: ObjectCount
+    # Datasets referenced by this pipeline's activities.
+    datasets: ObjectCount
+    # Linked services referenced by this pipeline (directly or transitively
+    # through its datasets).
+    linked_services: ObjectCount
+    # Total counts for the pipeline (mirrors ``.activities.total`` etc. plus
+    # adds the trigger / integration-runtime totals that aren't broken down by
+    # supported/unsupported).
+    total_activities: int = 0
+    total_datasets: int = 0
+    total_linked_services: int = 0
+    total_triggers: int = 0
+    total_integration_runtimes: int = 0
+
+
+@dataclass(slots=True)
 class FactoryProfile:
     """Complete profile of an Azure Data Factory resource."""
 
@@ -46,5 +78,6 @@ class FactoryProfile:
     integration_runtimes: ObjectCount
     dataset_details: list[DatasetDetail] = field(default_factory=list)
     integration_runtime_details: list[IntegrationRuntimeDetail] = field(default_factory=list)
+    pipeline_details: list[PipelineDetail] = field(default_factory=list)
     unsupported_activity_types: list[str] = field(default_factory=list)
     unsupported_dataset_types: list[str] = field(default_factory=list)

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -6,8 +6,8 @@ import logging
 import re
 from typing import Any
 
-import wkmigrate.translators.activity_translators.activity_translator as _activity_reg  # noqa: F401
-import wkmigrate.translators.dataset_translators.dataset_translator as _dataset_reg  # noqa: F401
+import wkmigrate.translators.activity_translators.activity_translator as _activity_translator_registry  # noqa: F401
+import wkmigrate.translators.dataset_translators.dataset_translator as _dataset_translator_registry  # noqa: F401
 from wkmigrate.clients.factory_client import FactoryClient
 from wkmigrate.profiler.profile import (
     DatasetDetail,
@@ -81,8 +81,8 @@ def profile_factory(
 
     activity_counts, unsupported_activity_types = _count_activities(pipelines)
     dataset_counts, dataset_details, unsupported_dataset_types = _count_datasets(datasets, linked_services)
-    ls_counts = _count_linked_services(linked_services)
-    ir_counts, ir_details = _build_integration_runtime_details(integration_runtimes)
+    linked_service_counts = _count_linked_services(linked_services)
+    integration_runtime_counts, integration_runtime_details = _build_integration_runtime_details(integration_runtimes)
     pipeline_details = _build_pipeline_details(
         pipelines=pipelines,
         datasets=datasets,
@@ -95,12 +95,12 @@ def profile_factory(
         factory_name=resolved_factory_name,
         pipelines=ObjectCount(len(pipelines), len(pipelines), 0),
         activities=activity_counts,
-        linked_services=ls_counts,
+        linked_services=linked_service_counts,
         datasets=dataset_counts,
         triggers=ObjectCount(len(triggers), len(triggers), 0),
-        integration_runtimes=ir_counts,
+        integration_runtimes=integration_runtime_counts,
         dataset_details=dataset_details,
-        integration_runtime_details=ir_details,
+        integration_runtime_details=integration_runtime_details,
         pipeline_details=pipeline_details,
         unsupported_activity_types=unsupported_activity_types,
         unsupported_dataset_types=unsupported_dataset_types,
@@ -145,15 +145,20 @@ def format_profile(profile: FactoryProfile) -> str:
     if profile.dataset_details:
         lines += ["", "Dataset Details:"]
         for detail in profile.dataset_details:
-            ls_name = detail.linked_service_name or "N/A"
-            ls_type = detail.linked_service_type or "N/A"
-            lines.append(f"  - {detail.dataset_name} ({detail.dataset_type}) via {ls_name} [{ls_type}]")
+            linked_service_name = detail.linked_service_name or "N/A"
+            linked_service_type = detail.linked_service_type or "N/A"
+            lines.append(
+                f"  - {detail.dataset_name} ({detail.dataset_type}) "
+                f"via {linked_service_name} [{linked_service_type}]"
+            )
 
     if profile.integration_runtime_details:
         lines += ["", "Integration Runtimes:"]
-        for irt in profile.integration_runtime_details:
-            node_info = f", {irt.node_count} nodes" if irt.node_count is not None else ""
-            lines.append(f"  - {irt.name} ({irt.runtime_type}{node_info})")
+        for integration_runtime in profile.integration_runtime_details:
+            node_info = (
+                f", {integration_runtime.node_count} nodes" if integration_runtime.node_count is not None else ""
+            )
+            lines.append(f"  - {integration_runtime.name} ({integration_runtime.runtime_type}{node_info})")
 
     if profile.pipeline_details:
         lines += ["", "Pipeline Details:"]
@@ -266,7 +271,7 @@ def _arm_to_snake(value: Any) -> Any:
         A new structure with the same shape and snake_cased keys.
     """
     if isinstance(value, dict):
-        return {_camel_to_snake(k): _arm_to_snake(v) for k, v in value.items()}
+        return {_camel_to_snake(key): _arm_to_snake(inner_value) for key, inner_value in value.items()}
     if isinstance(value, list):
         return [_arm_to_snake(item) for item in value]
     return value
@@ -310,22 +315,26 @@ def _build_pipeline_details(
         A list of ``PipelineDetail`` objects for each pipeline.
     """
     del integration_runtimes  # see docstring — derived from linked-service connect_via
-    dataset_by_name = {ds.get("name", ""): ds for ds in datasets if isinstance(ds, dict)}
-    ls_by_name = {ls.get("name", ""): ls for ls in linked_services if isinstance(ls, dict)}
+    dataset_by_name = {dataset.get("name", ""): dataset for dataset in datasets if isinstance(dataset, dict)}
+    linked_service_by_name = {
+        linked_service.get("name", ""): linked_service
+        for linked_service in linked_services
+        if isinstance(linked_service, dict)
+    }
 
     details: list[PipelineDetail] = []
     for pipeline in pipelines:
         if not isinstance(pipeline, dict):
             logger.warning("Skipping non-dictionary pipeline in pipeline_details computation")
             continue
-        details.append(_build_pipeline_detail(pipeline, dataset_by_name, ls_by_name, triggers))
+        details.append(_build_pipeline_detail(pipeline, dataset_by_name, linked_service_by_name, triggers))
     return details
 
 
 def _build_pipeline_detail(
     pipeline: dict,
     dataset_by_name: dict[str, dict],
-    ls_by_name: dict[str, dict],
+    linked_service_by_name: dict[str, dict],
     triggers: list[dict],
 ) -> PipelineDetail:
     """Builds a single ``PipelineDetail`` by delegating each sub-computation to a helper.
@@ -333,7 +342,7 @@ def _build_pipeline_detail(
     Args:
         pipeline: Pipeline definition in snake-case shape.
         dataset_by_name: Name → dataset index for the factory.
-        ls_by_name: Name → linked-service index for the factory.
+        linked_service_by_name: Name → linked-service index for the factory.
         triggers: All triggers in the factory.
 
     Returns:
@@ -344,23 +353,25 @@ def _build_pipeline_detail(
 
     activity_counts = _classify_pipeline_activities(activities)
     referenced_dataset_names, dataset_counts = _classify_pipeline_datasets(activities, dataset_by_name)
-    linked_service_names, ls_counts = _classify_pipeline_linked_services(
+    linked_service_names, linked_service_counts = _classify_pipeline_linked_services(
         activities=activities,
         referenced_dataset_names=referenced_dataset_names,
         dataset_by_name=dataset_by_name,
-        ls_by_name=ls_by_name,
+        linked_service_by_name=linked_service_by_name,
     )
 
     return PipelineDetail(
         pipeline_name=pipeline_name,
         activities=activity_counts,
         datasets=dataset_counts,
-        linked_services=ls_counts,
+        linked_services=linked_service_counts,
         total_activities=activity_counts.total,
         total_datasets=dataset_counts.total,
-        total_linked_services=ls_counts.total,
+        total_linked_services=linked_service_counts.total,
         total_triggers=_count_triggers_for_pipeline(pipeline_name, triggers),
-        total_integration_runtimes=_count_integration_runtimes_for_pipeline(linked_service_names, ls_by_name),
+        total_integration_runtimes=_count_integration_runtimes_for_pipeline(
+            linked_service_names, linked_service_by_name
+        ),
     )
 
 
@@ -403,31 +414,31 @@ def _classify_pipeline_linked_services(
     activities: list[dict],
     referenced_dataset_names: set[str],
     dataset_by_name: dict[str, dict],
-    ls_by_name: dict[str, dict],
+    linked_service_by_name: dict[str, dict],
 ) -> tuple[set[str], ObjectCount]:
     """Resolves the linked services a pipeline reaches and classifies them.
 
     A pipeline reaches a linked service in two ways: directly (an activity
     such as ``WebActivity`` or ``SqlServerStoredProcedure`` carries a
     ``LinkedServiceReference``) or transitively (an activity references a
-    dataset whose ``linked_service_name`` points at the LS).  Both paths are
-    unioned before classification.
+    dataset whose ``linked_service_name`` points at the linked service).
+    Both paths are unioned before classification.
 
     Args:
         activities: Flat list of activity dicts.
         referenced_dataset_names: Datasets already known to be referenced by
             this pipeline; their ``linked_service_name`` fields contribute the
-            transitive set of LS reachable via datasets.
+            transitive set of linked services reachable via datasets.
         dataset_by_name: Name → dataset index.
-        ls_by_name: Name → linked-service index.
+        linked_service_by_name: Name → linked-service index.
 
     Returns:
         ``(linked_service_names, ObjectCount)``.  The set is returned so the
         caller can pass it to :func:`_count_integration_runtimes_for_pipeline`.
     """
-    linked_service_names = set(_collect_referenced_linked_service_names(activities, ls_by_name))
+    linked_service_names = set(_collect_referenced_linked_service_names(activities, linked_service_by_name))
     linked_service_names |= _collect_linked_service_names_from_datasets(referenced_dataset_names, dataset_by_name)
-    supported, unsupported = _count_supported_linked_service_refs(linked_service_names, ls_by_name)
+    supported, unsupported = _count_supported_linked_service_refs(linked_service_names, linked_service_by_name)
     return linked_service_names, ObjectCount(
         total=len(linked_service_names), supported=supported, unsupported=unsupported
     )
@@ -446,14 +457,16 @@ def _collect_linked_service_names_from_datasets(
         Unique LS names referenced by the given datasets.
     """
     found: set[str] = set()
-    for ds_name in referenced_dataset_names:
-        dataset = dataset_by_name.get(ds_name)
+    for dataset_name in referenced_dataset_names:
+        dataset = dataset_by_name.get(dataset_name)
         if dataset is None:
             continue
-        ls_ref = (dataset.get("properties") or {}).get("linked_service_name") or {}
-        ref_name = ls_ref.get("reference_name") if isinstance(ls_ref, dict) else None
-        if ref_name:
-            found.add(ref_name)
+        linked_service_reference = (dataset.get("properties") or {}).get("linked_service_name") or {}
+        reference_name = (
+            linked_service_reference.get("reference_name") if isinstance(linked_service_reference, dict) else None
+        )
+        if reference_name:
+            found.add(reference_name)
     return found
 
 
@@ -473,13 +486,13 @@ def _count_supported_dataset_refs(
     """
     supported = 0
     unsupported = 0
-    for ds_name in referenced_dataset_names:
-        dataset = dataset_by_name.get(ds_name)
+    for dataset_name in referenced_dataset_names:
+        dataset = dataset_by_name.get(dataset_name)
         if dataset is None:
             unsupported += 1
             continue
-        ds_type = (dataset.get("properties") or {}).get("type") or "Unknown"
-        if ds_type in SUPPORTED_DATASET_TYPES:
+        dataset_type = (dataset.get("properties") or {}).get("type") or "Unknown"
+        if dataset_type in SUPPORTED_DATASET_TYPES:
             supported += 1
         else:
             unsupported += 1
@@ -487,27 +500,27 @@ def _count_supported_dataset_refs(
 
 
 def _count_supported_linked_service_refs(
-    linked_service_names: set[str], ls_by_name: dict[str, dict]
+    linked_service_names: set[str], linked_service_by_name: dict[str, dict]
 ) -> tuple[int, int]:
-    """Tallies ``(supported, unsupported)`` references by looking up each LS's type.
+    """Tallies ``(supported, unsupported)`` references by looking up each linked service's type.
 
     Args:
-        linked_service_names: LS names to classify.
-        ls_by_name: Name → linked-service index.  Unknown names count as
-            unsupported.
+        linked_service_names: Linked-service names to classify.
+        linked_service_by_name: Name → linked-service index.  Unknown names
+            count as unsupported.
 
     Returns:
         ``(supported, unsupported)``.
     """
     supported = 0
     unsupported = 0
-    for ls_name in linked_service_names:
-        ls = ls_by_name.get(ls_name)
-        if ls is None:
+    for linked_service_name in linked_service_names:
+        linked_service = linked_service_by_name.get(linked_service_name)
+        if linked_service is None:
             unsupported += 1
             continue
-        ls_type = (ls.get("properties") or {}).get("type") or "Unknown"
-        if ls_type in SUPPORTED_LINKED_SERVICE_TYPES:
+        linked_service_type = (linked_service.get("properties") or {}).get("type") or "Unknown"
+        if linked_service_type in SUPPORTED_LINKED_SERVICE_TYPES:
             supported += 1
         else:
             unsupported += 1
@@ -515,66 +528,68 @@ def _count_supported_linked_service_refs(
 
 
 def _count_integration_runtimes_for_pipeline(
-    linked_service_names: set[str], ls_by_name: dict[str, dict]
+    linked_service_names: set[str], linked_service_by_name: dict[str, dict]
 ) -> int:
-    """Counts distinct integration runtimes reached via the given LS's ``connect_via``.
+    """Counts distinct integration runtimes reached via each linked service's ``connect_via``.
 
     Args:
-        linked_service_names: LS names the pipeline reaches.
-        ls_by_name: Name → linked-service index.
+        linked_service_names: Linked-service names the pipeline reaches.
+        linked_service_by_name: Name → linked-service index.
 
     Returns:
-        Count of unique IR names referenced.
+        Count of unique integration-runtime names referenced.
     """
-    ir_names: set[str] = set()
-    for ls_name in linked_service_names:
-        ls = ls_by_name.get(ls_name)
-        if ls is None:
+    integration_runtime_names: set[str] = set()
+    for linked_service_name in linked_service_names:
+        linked_service = linked_service_by_name.get(linked_service_name)
+        if linked_service is None:
             continue
-        connect_via = (ls.get("properties") or {}).get("connect_via") or {}
-        ref_name = connect_via.get("reference_name") if isinstance(connect_via, dict) else None
-        if ref_name:
-            ir_names.add(ref_name)
-    return len(ir_names)
+        connect_via = (linked_service.get("properties") or {}).get("connect_via") or {}
+        reference_name = connect_via.get("reference_name") if isinstance(connect_via, dict) else None
+        if reference_name:
+            integration_runtime_names.add(reference_name)
+    return len(integration_runtime_names)
 
 
 def _collect_referenced_dataset_names(activities: list[dict], dataset_by_name: dict[str, dict]) -> set[str]:
     """Walks the activity tree and collects dataset references.
 
     Args:
-        activities: Flat list of activity dicts
-        dataset_by_name: Index used to filter dataset candidates
+        activities: Flat list of activity dicts.
+        dataset_by_name: Index used to filter dataset candidates.
 
     Returns:
         Unique dataset names referenced anywhere in the activity tree.
     """
     found: set[str] = set()
     for activity in activities:
-        for ref_name, ref_type in _iter_reference_pairs(activity):
-            if ref_type == "DatasetReference" and ref_name in dataset_by_name:
-                found.add(ref_name)
-            elif ref_type is None and ref_name in dataset_by_name:
+        for reference_name, reference_type in _iter_reference_pairs(activity):
+            if reference_type == "DatasetReference" and reference_name in dataset_by_name:
+                found.add(reference_name)
+            elif reference_type is None and reference_name in dataset_by_name:
                 # Some activity shapes drop the ``type`` field on references.
                 # Fall back to a name-match.
-                found.add(ref_name)
+                found.add(reference_name)
     return found
 
 
-def _collect_referenced_linked_service_names(activities: list[dict], ls_by_name: dict[str, dict]) -> set[str]:
+def _collect_referenced_linked_service_names(
+    activities: list[dict], linked_service_by_name: dict[str, dict]
+) -> set[str]:
     """Walks the activity tree to collect linked-service references.
 
     Args:
         activities: Flat list of activity dicts.
-        ls_by_name: Index used to filter linked service reference candidates.
+        linked_service_by_name: Index used to filter linked-service reference candidates.
 
     Returns:
         Unique linked-service names referenced directly by activities.
     """
     found: set[str] = set()
     for activity in activities:
-        for ref_name, ref_type in _iter_reference_pairs(activity):
-            if ref_type == "LinkedServiceReference" and ref_name in ls_by_name:
-                found.add(ref_name)
+        for reference_name, reference_type in _iter_reference_pairs(activity):
+            if reference_type == "LinkedServiceReference" and reference_name in linked_service_by_name:
+                found.add(reference_name)
     return found
 
 
@@ -588,12 +603,12 @@ def _iter_reference_pairs(value: Any):
         Pairs of ``(reference_name, type_or_None)`` discovered in *value*.
     """
     if isinstance(value, dict):
-        ref_name = value.get("reference_name")
-        ref_type = value.get("type")
-        if isinstance(ref_name, str):
-            yield ref_name, ref_type if isinstance(ref_type, str) else None
-        for nested in value.values():
-            yield from _iter_reference_pairs(nested)
+        reference_name = value.get("reference_name")
+        reference_type = value.get("type")
+        if isinstance(reference_name, str):
+            yield reference_name, reference_type if isinstance(reference_type, str) else None
+        for nested_value in value.values():
+            yield from _iter_reference_pairs(nested_value)
     elif isinstance(value, list):
         for item in value:
             yield from _iter_reference_pairs(item)
@@ -615,11 +630,11 @@ def _count_triggers_for_pipeline(pipeline_name: str, triggers: list[dict]) -> in
         if not isinstance(trigger, dict):
             continue
         bound_pipelines = (trigger.get("properties") or {}).get("pipelines") or []
-        for bound in bound_pipelines:
-            if not isinstance(bound, dict):
+        for bound_pipeline in bound_pipelines:
+            if not isinstance(bound_pipeline, dict):
                 continue
-            ref = bound.get("pipeline_reference") or {}
-            if isinstance(ref, dict) and ref.get("reference_name") == pipeline_name:
+            pipeline_reference = bound_pipeline.get("pipeline_reference") or {}
+            if isinstance(pipeline_reference, dict) and pipeline_reference.get("reference_name") == pipeline_name:
                 count += 1
                 break
     return count
@@ -660,34 +675,36 @@ def _count_datasets(
     Returns:
         A tuple of ``(ObjectCount, dataset_details, unsupported_type_names)``.
     """
-    ls_type_map = _build_linked_service_type_map(linked_services)
+    linked_service_type_map = _build_linked_service_type_map(linked_services)
 
     supported = 0
     unsupported = 0
     unsupported_types: set[str] = set()
     details: list[DatasetDetail] = []
 
-    for dset in datasets:
-        props = dset.get("properties", {})
-        ds_type = props.get("type") or "Unknown"
-        ls_ref = props.get("linked_service_name", {})
-        ls_name = ls_ref.get("reference_name") if isinstance(ls_ref, dict) else None
-        ls_type = ls_type_map.get(ls_name) if ls_name else None
+    for dataset in datasets:
+        properties = dataset.get("properties", {})
+        dataset_type = properties.get("type") or "Unknown"
+        linked_service_reference = properties.get("linked_service_name", {})
+        linked_service_name = (
+            linked_service_reference.get("reference_name") if isinstance(linked_service_reference, dict) else None
+        )
+        linked_service_type = linked_service_type_map.get(linked_service_name) if linked_service_name else None
 
         details.append(
             DatasetDetail(
-                dataset_name=dset.get("name", "Unknown"),
-                dataset_type=ds_type,
-                linked_service_name=ls_name,
-                linked_service_type=ls_type,
+                dataset_name=dataset.get("name", "Unknown"),
+                dataset_type=dataset_type,
+                linked_service_name=linked_service_name,
+                linked_service_type=linked_service_type,
             )
         )
 
-        if ds_type in SUPPORTED_DATASET_TYPES:
+        if dataset_type in SUPPORTED_DATASET_TYPES:
             supported += 1
         else:
             unsupported += 1
-            unsupported_types.add(ds_type)
+            unsupported_types.add(dataset_type)
 
     total = supported + unsupported
     return ObjectCount(total, supported, unsupported), details, sorted(unsupported_types)
@@ -696,7 +713,9 @@ def _count_datasets(
 def _count_linked_services(linked_services: list[dict]) -> ObjectCount:
     """Count supported vs unsupported linked services."""
     supported = sum(
-        1 for ls in linked_services if ls.get("properties", {}).get("type") in SUPPORTED_LINKED_SERVICE_TYPES
+        1
+        for linked_service in linked_services
+        if linked_service.get("properties", {}).get("type") in SUPPORTED_LINKED_SERVICE_TYPES
     )
     total = len(linked_services)
     return ObjectCount(total, supported, total - supported)
@@ -708,18 +727,20 @@ def _build_integration_runtime_details(
     """Build integration runtime details and counts.
 
     Returns:
-        A tuple of ``(ObjectCount, ir_details)``.
+        A tuple of ``(ObjectCount, integration_runtime_details)``.
     """
     details: list[IntegrationRuntimeDetail] = []
-    for irt in integration_runtimes:
-        props = irt.get("properties", {})
+    for integration_runtime in integration_runtimes:
+        properties = integration_runtime.get("properties", {})
         node_count = None
-        if props.get("type") == "SelfHosted":
-            node_count = props.get("type_properties", {}).get("compute_properties", {}).get("number_of_nodes")
+        if properties.get("type") == "SelfHosted":
+            node_count = (
+                properties.get("type_properties", {}).get("compute_properties", {}).get("number_of_nodes")
+            )
         details.append(
             IntegrationRuntimeDetail(
-                name=irt.get("name", "Unknown"),
-                runtime_type=props.get("type", "Unknown"),
+                name=integration_runtime.get("name", "Unknown"),
+                runtime_type=properties.get("type", "Unknown"),
                 node_count=node_count,
             )
         )
@@ -762,4 +783,7 @@ def _build_linked_service_type_map(linked_services: list[dict]) -> dict[str, str
     Returns:
         Mapping from linked service name to its type string.
     """
-    return {ls.get("name", ""): ls.get("properties", {}).get("type") for ls in linked_services}
+    return {
+        linked_service.get("name", ""): linked_service.get("properties", {}).get("type")
+        for linked_service in linked_services
+    }

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import re
+from typing import Any
 
 # Import translator dispatchers first so every @translates_activity /
 # @translates_dataset decorator fires before we read the sets.
@@ -14,6 +16,7 @@ from wkmigrate.profiler.profile import (
     FactoryProfile,
     IntegrationRuntimeDetail,
     ObjectCount,
+    PipelineDetail,
 )
 from wkmigrate.supported_types import (
     SUPPORTED_ACTIVITY_TYPES,
@@ -23,29 +26,89 @@ from wkmigrate.supported_types import (
 
 logger = logging.getLogger(__name__)
 
+# ARM resource types used in factory export JSON.  Matching is case-insensitive
+# because Azure portal exports the segment names with mixed casing
+# (``linkedServices`` vs ``linkedservices``, ``integrationRuntimes`` vs
+# ``integrationruntimes``).
+_ARM_PIPELINE_TYPE = "microsoft.datafactory/factories/pipelines"
+_ARM_DATASET_TYPE = "microsoft.datafactory/factories/datasets"
+_ARM_LINKED_SERVICE_TYPE = "microsoft.datafactory/factories/linkedservices"
+_ARM_TRIGGER_TYPE = "microsoft.datafactory/factories/triggers"
+_ARM_INTEGRATION_RUNTIME_TYPE = "microsoft.datafactory/factories/integrationruntimes"
+_ARM_FACTORY_TYPE = "microsoft.datafactory/factories"
 
-def profile_factory(client: FactoryClient) -> FactoryProfile:
+
+def profile_factory(
+    client: FactoryClient | None = None,
+    *,
+    arm_template: dict[str, Any] | None = None,
+    factory_name: str | None = None,
+) -> FactoryProfile:
     """Profile an Azure Data Factory resource.
 
+    Pass either an authenticated ``FactoryClient`` for live profiling against a
+    deployed Data Factory, or an ``arm_template`` dict for offline profiling
+    against an exported ARM JSON template (e.g. ``ARMTemplateForFactory.json``).
+    Exactly one of the two must be provided.
+
     Args:
-        client: Authenticated ``FactoryClient`` for the target factory.
+        client: Authenticated ``FactoryClient`` for the target factory.  When
+            omitted, ``arm_template`` must be supplied instead.
+        arm_template: Parsed Azure Resource Manager template for an ADF
+            factory.  The ``resources`` array is filtered by the standard
+            ``Microsoft.DataFactory/factories/*`` types and field names are
+            normalised from ARM camelCase to the SDK's snake_case shape so the
+            downstream helpers work without branching on input source.
+        factory_name: Override for the factory display name.  Required when
+            profiling an ARM template that does not embed a
+            ``Microsoft.DataFactory/factories`` resource.  Ignored when
+            ``client`` is supplied.
 
     Returns:
-        A ``FactoryProfile`` summarising the factory contents.
+        A ``FactoryProfile`` summarising the factory contents, including a
+        per-pipeline breakdown in ``pipeline_details``.
+
+    Raises:
+        ValueError: If neither ``client`` nor ``arm_template`` was supplied,
+            or if both were supplied.
     """
-    pipelines = client.list_pipeline_definitions()
-    datasets = client.list_datasets()
-    linked_services = client.list_linked_services()
-    triggers = client.list_triggers()
-    integration_runtimes = client.list_integration_runtimes()
+    if client is not None and arm_template is not None:
+        raise ValueError("Pass either client= or arm_template=, not both.")
+    if client is None and arm_template is None:
+        raise ValueError("One of client= or arm_template= must be provided.")
+
+    if client is not None:
+        resolved_factory_name = client.factory_name
+        pipelines = client.list_pipeline_definitions()
+        datasets = client.list_datasets()
+        linked_services = client.list_linked_services()
+        triggers = client.list_triggers()
+        integration_runtimes = client.list_integration_runtimes()
+    else:
+        # arm_template is not None per the guard above; mypy/typecheckers
+        # benefit from the local rebind.
+        loaded = _load_from_arm(arm_template, factory_name_override=factory_name)
+        resolved_factory_name = loaded["factory_name"]
+        pipelines = loaded["pipelines"]
+        datasets = loaded["datasets"]
+        linked_services = loaded["linked_services"]
+        triggers = loaded["triggers"]
+        integration_runtimes = loaded["integration_runtimes"]
 
     activity_counts, unsupported_activity_types = _count_activities(pipelines)
     dataset_counts, dataset_details, unsupported_dataset_types = _count_datasets(datasets, linked_services)
     ls_counts = _count_linked_services(linked_services)
     ir_counts, ir_details = _build_integration_runtime_details(integration_runtimes)
+    pipeline_details = _build_pipeline_details(
+        pipelines=pipelines,
+        datasets=datasets,
+        linked_services=linked_services,
+        triggers=triggers,
+        integration_runtimes=integration_runtimes,
+    )
 
     return FactoryProfile(
-        factory_name=client.factory_name,
+        factory_name=resolved_factory_name,
         pipelines=ObjectCount(len(pipelines), len(pipelines), 0),
         activities=activity_counts,
         linked_services=ls_counts,
@@ -54,6 +117,7 @@ def profile_factory(client: FactoryClient) -> FactoryProfile:
         integration_runtimes=ir_counts,
         dataset_details=dataset_details,
         integration_runtime_details=ir_details,
+        pipeline_details=pipeline_details,
         unsupported_activity_types=unsupported_activity_types,
         unsupported_dataset_types=unsupported_dataset_types,
     )
@@ -107,7 +171,418 @@ def format_profile(profile: FactoryProfile) -> str:
             node_info = f", {irt.node_count} nodes" if irt.node_count is not None else ""
             lines.append(f"  - {irt.name} ({irt.runtime_type}{node_info})")
 
+    if profile.pipeline_details:
+        lines += ["", "Pipeline Details:"]
+        for pd in profile.pipeline_details:
+            lines.append(f"  - {pd.pipeline_name}")
+            lines.append(
+                f"      Activities:      {pd.activities.total}"
+                f" ({pd.activities.supported} supported, {pd.activities.unsupported} unsupported)"
+            )
+            lines.append(
+                f"      Datasets:        {pd.datasets.total}"
+                f" ({pd.datasets.supported} supported, {pd.datasets.unsupported} unsupported)"
+            )
+            lines.append(
+                f"      Linked Services: {pd.linked_services.total}"
+                f" ({pd.linked_services.supported} supported, {pd.linked_services.unsupported} unsupported)"
+            )
+            lines.append(
+                f"      Triggers: {pd.total_triggers}, Integration Runtimes: {pd.total_integration_runtimes}"
+            )
+
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# ARM template loader
+# ---------------------------------------------------------------------------
+
+
+def _load_from_arm(
+    arm_template: dict[str, Any], *, factory_name_override: str | None = None
+) -> dict[str, Any]:
+    """Extracts ADF resources from an ARM template and normalises their shape.
+
+    The Azure Portal export uses ARM camelCase field names and nests pipeline
+    activities under ``properties.activities``.  The SDK ``as_dict()`` output
+    (and therefore the existing counter helpers) expects snake_case fields and
+    pipeline activities lifted to the top level.  This loader translates ARM
+    JSON into that internal shape so the rest of the profiler stays oblivious
+    to the input source.
+
+    Args:
+        arm_template: Parsed ARM template dict.  The ``resources`` array is
+            scanned; everything outside the Data Factory resource types is
+            ignored.
+        factory_name_override: Optional factory display name.  Used when the
+            ARM template does not include a top-level
+            ``Microsoft.DataFactory/factories`` resource.
+
+    Returns:
+        Dict with keys ``factory_name``, ``pipelines``, ``datasets``,
+        ``linked_services``, ``triggers``, and ``integration_runtimes``.
+    """
+    resources = arm_template.get("resources") or []
+    pipelines: list[dict] = []
+    datasets: list[dict] = []
+    linked_services: list[dict] = []
+    triggers: list[dict] = []
+    integration_runtimes: list[dict] = []
+    factory_name: str | None = factory_name_override
+
+    for resource in resources:
+        if not isinstance(resource, dict):
+            continue
+        resource_type = (resource.get("type") or "").lower()
+        leaf_name = _leaf_resource_name(resource.get("name") or "")
+        properties = _arm_to_snake(resource.get("properties") or {})
+
+        if resource_type == _ARM_FACTORY_TYPE:
+            if factory_name is None:
+                factory_name = leaf_name
+        elif resource_type == _ARM_PIPELINE_TYPE:
+            # Lift activities to top-level to match SDK shape; preserve
+            # the snake-cased ``properties`` for any downstream readers.
+            pipelines.append(
+                {
+                    "name": leaf_name,
+                    "activities": properties.get("activities") or [],
+                    "parameters": properties.get("parameters") or {},
+                    "properties": properties,
+                }
+            )
+        elif resource_type == _ARM_DATASET_TYPE:
+            datasets.append({"name": leaf_name, "properties": properties})
+        elif resource_type == _ARM_LINKED_SERVICE_TYPE:
+            linked_services.append({"name": leaf_name, "properties": properties})
+        elif resource_type == _ARM_TRIGGER_TYPE:
+            triggers.append({"name": leaf_name, "properties": properties})
+        elif resource_type == _ARM_INTEGRATION_RUNTIME_TYPE:
+            integration_runtimes.append({"name": leaf_name, "properties": properties})
+
+    if factory_name is None:
+        factory_name = "Unknown"
+
+    return {
+        "factory_name": factory_name,
+        "pipelines": pipelines,
+        "datasets": datasets,
+        "linked_services": linked_services,
+        "triggers": triggers,
+        "integration_runtimes": integration_runtimes,
+    }
+
+
+def _leaf_resource_name(arm_name: str) -> str:
+    """Strips the ``factory-name/`` prefix from an ARM resource name.
+
+    ARM names for nested resources look like ``factory-name/pipeline-name``.
+    This helper returns just the leaf segment so the resource name matches
+    what the SDK returns.
+
+    Args:
+        arm_name: The raw ARM resource ``name`` field.
+
+    Returns:
+        The final ``/``-separated segment, or the input unchanged when there
+        is no slash.
+    """
+    if "/" not in arm_name:
+        return arm_name
+    return arm_name.split("/")[-1]
+
+
+_CAMEL_TO_SNAKE_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def _arm_to_snake(value: Any) -> Any:
+    """Recursively converts camelCase dict keys to snake_case.
+
+    Walks dicts and lists; leaves leaf values (strings, numbers, bools,
+    ``None``) untouched.
+
+    Args:
+        value: Any JSON-decoded value from an ARM template.
+
+    Returns:
+        A new structure with the same shape and snake_cased keys.
+    """
+    if isinstance(value, dict):
+        return {_camel_to_snake(k): _arm_to_snake(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_arm_to_snake(item) for item in value]
+    return value
+
+
+def _camel_to_snake(name: str) -> str:
+    """Converts a single camelCase identifier to snake_case.
+
+    Args:
+        name: Identifier to convert.
+
+    Returns:
+        snake_cased identifier; pass-through for already-snake names.
+    """
+    return _CAMEL_TO_SNAKE_RE.sub("_", name).lower()
+
+
+# ---------------------------------------------------------------------------
+# Per-pipeline detail computation
+# ---------------------------------------------------------------------------
+
+
+def _build_pipeline_details(
+    *,
+    pipelines: list[dict],
+    datasets: list[dict],
+    linked_services: list[dict],
+    triggers: list[dict],
+    integration_runtimes: list[dict],  # noqa: ARG001 -- accepted for caller symmetry
+) -> list[PipelineDetail]:
+    """Computes the per-pipeline breakdown used by ``FactoryProfile``.
+
+    For each pipeline, walks its activities (including nested ones inside
+    ``ForEach`` and ``IfCondition``) to collect activity types and any
+    ``reference_name`` strings that resolve to a known dataset or linked
+    service.  Linked-service references are augmented with the linked services
+    transitively reached via the pipeline's datasets so a dataset that points
+    at ``AzureSqlDatabase_LS`` counts toward the pipeline's linked-service
+    total even when the activity itself only names the dataset.
+
+    The integration-runtime count is derived from the ``connect_via``
+    reference on each linked service the pipeline reaches.
+
+    Args:
+        pipelines: Pipeline definitions in SDK (snake_case) shape.
+        datasets: Dataset definitions in SDK shape.
+        linked_services: Linked-service definitions in SDK shape.
+        triggers: Trigger definitions in SDK shape.
+        integration_runtimes: Integration-runtime definitions in SDK shape.
+            Accepted for API symmetry; the per-pipeline IR count is derived
+            from linked-service ``connect_via`` references.
+
+    Returns:
+        One ``PipelineDetail`` per pipeline, in input order.
+    """
+    dataset_by_name: dict[str, dict] = {ds.get("name", ""): ds for ds in datasets if isinstance(ds, dict)}
+    ls_by_name: dict[str, dict] = {ls.get("name", ""): ls for ls in linked_services if isinstance(ls, dict)}
+
+    details: list[PipelineDetail] = []
+    for pipeline in pipelines:
+        if not isinstance(pipeline, dict):
+            logger.warning("Skipping non-dictionary pipeline in pipeline_details computation")
+            continue
+        pipeline_name = pipeline.get("name", "Unknown")
+
+        # Walk every nested activity once
+        activities: list[dict] = []
+        _collect_activities(pipeline.get("activities") or [], activities)
+
+        # Activity supported/unsupported counts within this pipeline
+        activity_supported = sum(1 for a in activities if (a.get("type") or "Unknown") in SUPPORTED_ACTIVITY_TYPES)
+        activity_total = len(activities)
+        activity_counts = ObjectCount(
+            total=activity_total,
+            supported=activity_supported,
+            unsupported=activity_total - activity_supported,
+        )
+
+        # Datasets referenced by THIS pipeline's activities
+        referenced_dataset_names = _collect_referenced_dataset_names(activities, dataset_by_name)
+        ds_supported = 0
+        ds_unsupported = 0
+        for ds_name in referenced_dataset_names:
+            ds = dataset_by_name.get(ds_name)
+            if ds is None:
+                ds_unsupported += 1
+                continue
+            ds_type = (ds.get("properties") or {}).get("type") or "Unknown"
+            if ds_type in SUPPORTED_DATASET_TYPES:
+                ds_supported += 1
+            else:
+                ds_unsupported += 1
+        dataset_counts = ObjectCount(
+            total=len(referenced_dataset_names),
+            supported=ds_supported,
+            unsupported=ds_unsupported,
+        )
+
+        # Linked services: those referenced directly by activities + those
+        # reached transitively via referenced datasets
+        ls_names: set[str] = set()
+        ls_names.update(_collect_referenced_linked_service_names(activities, ls_by_name))
+        for ds_name in referenced_dataset_names:
+            ds = dataset_by_name.get(ds_name)
+            if ds is None:
+                continue
+            ls_ref = (ds.get("properties") or {}).get("linked_service_name") or {}
+            ls_ref_name = ls_ref.get("reference_name") if isinstance(ls_ref, dict) else None
+            if ls_ref_name:
+                ls_names.add(ls_ref_name)
+
+        ls_supported = 0
+        ls_unsupported = 0
+        for ls_name in sorted(ls_names):
+            ls = ls_by_name.get(ls_name)
+            if ls is None:
+                ls_unsupported += 1
+                continue
+            ls_type = (ls.get("properties") or {}).get("type") or "Unknown"
+            if ls_type in SUPPORTED_LINKED_SERVICE_TYPES:
+                ls_supported += 1
+            else:
+                ls_unsupported += 1
+        ls_counts = ObjectCount(
+            total=len(ls_names),
+            supported=ls_supported,
+            unsupported=ls_unsupported,
+        )
+
+        # Triggers binding this pipeline
+        trigger_count = _count_triggers_for_pipeline(pipeline_name, triggers)
+
+        # Distinct integration runtimes reached via this pipeline's linked services
+        ir_names: set[str] = set()
+        for ls_name in ls_names:
+            ls = ls_by_name.get(ls_name)
+            if ls is None:
+                continue
+            connect_via = (ls.get("properties") or {}).get("connect_via") or {}
+            ir_ref_name = connect_via.get("reference_name") if isinstance(connect_via, dict) else None
+            if ir_ref_name:
+                ir_names.add(ir_ref_name)
+
+        details.append(
+            PipelineDetail(
+                pipeline_name=pipeline_name,
+                activities=activity_counts,
+                datasets=dataset_counts,
+                linked_services=ls_counts,
+                total_activities=activity_counts.total,
+                total_datasets=dataset_counts.total,
+                total_linked_services=ls_counts.total,
+                total_triggers=trigger_count,
+                total_integration_runtimes=len(ir_names),
+            )
+        )
+
+    return details
+
+
+def _collect_referenced_dataset_names(
+    activities: list[dict], dataset_by_name: dict[str, dict]
+) -> set[str]:
+    """Walks the activity tree collecting every dataset reference.
+
+    Dataset references appear as ``{"reference_name": ..., "type":
+    "DatasetReference"}`` blocks across ``inputs``, ``outputs``,
+    ``type_properties.dataset``, ``type_properties.source.dataset``,
+    ``type_properties.sink.dataset``, and a handful of other locations.
+    Instead of enumerating every spot, walk every nested dict in each activity
+    and pick out ``reference_name`` strings whose name matches a known
+    dataset.
+
+    Args:
+        activities: Flat list of activity dicts (control-flow already expanded).
+        dataset_by_name: Index used to filter ``reference_name`` candidates so
+            we don't conflate linked-service or trigger references.
+
+    Returns:
+        Unique dataset names referenced anywhere in the activity tree.
+    """
+    found: set[str] = set()
+    for activity in activities:
+        for ref_name, ref_type in _iter_reference_pairs(activity):
+            if ref_type == "DatasetReference" and ref_name in dataset_by_name:
+                found.add(ref_name)
+            elif ref_type is None and ref_name in dataset_by_name:
+                # Some activity shapes drop the ``type`` field on references.
+                # Fall back to a name-match.
+                found.add(ref_name)
+    return found
+
+
+def _collect_referenced_linked_service_names(
+    activities: list[dict], ls_by_name: dict[str, dict]
+) -> set[str]:
+    """Walks the activity tree collecting every linked-service reference.
+
+    Some activities (e.g. ``SqlServerStoredProcedure``, ``WebActivity`` auth)
+    reference linked services directly without going through a dataset.
+
+    Args:
+        activities: Flat list of activity dicts.
+        ls_by_name: Index used to filter ``reference_name`` candidates.
+
+    Returns:
+        Unique linked-service names referenced directly by activities.
+    """
+    found: set[str] = set()
+    for activity in activities:
+        for ref_name, ref_type in _iter_reference_pairs(activity):
+            if ref_type == "LinkedServiceReference" and ref_name in ls_by_name:
+                found.add(ref_name)
+    return found
+
+
+def _iter_reference_pairs(value: Any):
+    """Yields every ``(reference_name, type)`` pair found recursively in *value*.
+
+    ADF nests references as ``{"reference_name": "...", "type": "..."}`` (SDK
+    shape).  This helper walks dicts and lists yielding those pairs so the
+    caller can filter by reference type without enumerating every nesting site.
+
+    Args:
+        value: Any dict / list / scalar.
+
+    Yields:
+        Pairs of ``(reference_name, type_or_None)`` discovered in *value*.
+    """
+    if isinstance(value, dict):
+        ref_name = value.get("reference_name")
+        ref_type = value.get("type")
+        if isinstance(ref_name, str):
+            yield ref_name, ref_type if isinstance(ref_type, str) else None
+        for nested in value.values():
+            yield from _iter_reference_pairs(nested)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_reference_pairs(item)
+
+
+def _count_triggers_for_pipeline(pipeline_name: str, triggers: list[dict]) -> int:
+    """Counts triggers that bind to a given pipeline.
+
+    A trigger's ``properties.pipelines`` array carries ``pipeline_reference``
+    blocks; we match against the ``reference_name`` field.
+
+    Args:
+        pipeline_name: Logical pipeline name to match.
+        triggers: All triggers in the factory.
+
+    Returns:
+        Number of triggers that include *pipeline_name* in their pipeline
+        reference list.
+    """
+    count = 0
+    for trigger in triggers:
+        if not isinstance(trigger, dict):
+            continue
+        bound_pipelines = (trigger.get("properties") or {}).get("pipelines") or []
+        for bound in bound_pipelines:
+            if not isinstance(bound, dict):
+                continue
+            ref = bound.get("pipeline_reference") or {}
+            if isinstance(ref, dict) and ref.get("reference_name") == pipeline_name:
+                count += 1
+                break
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Factory-wide counters (unchanged behaviour)
+# ---------------------------------------------------------------------------
 
 
 def _count_activities(pipelines: list) -> tuple[ObjectCount, list[str]]:

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -6,8 +6,6 @@ import logging
 import re
 from typing import Any
 
-# Import translator dispatchers first so every @translates_activity /
-# @translates_dataset decorator fires before we read the sets.
 import wkmigrate.translators.activity_translators.activity_translator as _activity_reg  # noqa: F401
 import wkmigrate.translators.dataset_translators.dataset_translator as _dataset_reg  # noqa: F401
 from wkmigrate.clients.factory_client import FactoryClient
@@ -26,10 +24,6 @@ from wkmigrate.supported_types import (
 
 logger = logging.getLogger(__name__)
 
-# ARM resource types used in factory export JSON.  Matching is case-insensitive
-# because Azure portal exports the segment names with mixed casing
-# (``linkedServices`` vs ``linkedservices``, ``integrationRuntimes`` vs
-# ``integrationruntimes``).
 _ARM_PIPELINE_TYPE = "microsoft.datafactory/factories/pipelines"
 _ARM_DATASET_TYPE = "microsoft.datafactory/factories/datasets"
 _ARM_LINKED_SERVICE_TYPE = "microsoft.datafactory/factories/linkedservices"
@@ -44,38 +38,29 @@ def profile_factory(
     arm_template: dict[str, Any] | None = None,
     factory_name: str | None = None,
 ) -> FactoryProfile:
-    """Profile an Azure Data Factory resource.
+    """Profiles an Azure Data Factory resource.
 
-    Pass either an authenticated ``FactoryClient`` for live profiling against a
-    deployed Data Factory, or an ``arm_template`` dict for offline profiling
-    against an exported ARM JSON template (e.g. ``ARMTemplateForFactory.json``).
-    Exactly one of the two must be provided.
+    Uses either an authenticated FactoryClient to profile using API calls against a deployed
+    Data Factory or an ARM template dict for offline profiling against exported ARM templates
+    (e.g. 'ARMTemplateForFactory.json').
 
     Args:
-        client: Authenticated ``FactoryClient`` for the target factory.  When
-            omitted, ``arm_template`` must be supplied instead.
-        arm_template: Parsed Azure Resource Manager template for an ADF
-            factory.  The ``resources`` array is filtered by the standard
-            ``Microsoft.DataFactory/factories/*`` types and field names are
-            normalised from ARM camelCase to the SDK's snake_case shape so the
-            downstream helpers work without branching on input source.
-        factory_name: Override for the factory display name.  Required when
-            profiling an ARM template that does not embed a
-            ``Microsoft.DataFactory/factories`` resource.  Ignored when
-            ``client`` is supplied.
+        client: Authenticated FactoryClient for the target factory.
+        arm_template: Parsed ARM JSON template.
+        factory_name: Override for the factory display name. Required when profiling an ARM
+            template that does not embed a ``Microsoft.DataFactory/factories`` resource.
+            Ignored when a client is supplied.
 
     Returns:
-        A ``FactoryProfile`` summarising the factory contents, including a
-        per-pipeline breakdown in ``pipeline_details``.
+        A ``FactoryProfile`` summarising the factory contents.
 
     Raises:
-        ValueError: If neither ``client`` nor ``arm_template`` was supplied,
-            or if both were supplied.
+        ValueError: If neither 'client' nor 'arm_template' was supplied, or if both were supplied.
     """
     if client is not None and arm_template is not None:
-        raise ValueError("Pass either client= or arm_template=, not both.")
+        raise ValueError("'client' and 'arm_template' must not both be provided")
     if client is None and arm_template is None:
-        raise ValueError("One of client= or arm_template= must be provided.")
+        raise ValueError("Either 'client' or 'arm_template' must be provided")
 
     if client is not None:
         resolved_factory_name = client.factory_name
@@ -85,8 +70,7 @@ def profile_factory(
         triggers = client.list_triggers()
         integration_runtimes = client.list_integration_runtimes()
     else:
-        # arm_template is not None per the guard above; mypy/typecheckers
-        # benefit from the local rebind.
+        # arm_template is not None per the guards above; rebind for the typechecker.
         loaded = _load_from_arm(arm_template, factory_name_override=factory_name)
         resolved_factory_name = loaded["factory_name"]
         pipelines = loaded["pipelines"]
@@ -124,7 +108,7 @@ def profile_factory(
 
 
 def format_profile(profile: FactoryProfile) -> str:
-    """Format a FactoryProfile as human-readable text.
+    """Formats a FactoryProfile as human-readable text.
 
     Args:
         profile: The factory profile to format.
@@ -173,55 +157,38 @@ def format_profile(profile: FactoryProfile) -> str:
 
     if profile.pipeline_details:
         lines += ["", "Pipeline Details:"]
-        for pd in profile.pipeline_details:
-            lines.append(f"  - {pd.pipeline_name}")
+        for pipeline_detail in profile.pipeline_details:
+            lines.append(f"  - {pipeline_detail.pipeline_name}")
             lines.append(
-                f"      Activities:      {pd.activities.total}"
-                f" ({pd.activities.supported} supported, {pd.activities.unsupported} unsupported)"
+                f"      Activities:      {pipeline_detail.activities.total}"
+                f" ({pipeline_detail.activities.supported} supported, {pipeline_detail.activities.unsupported} unsupported)"
             )
             lines.append(
-                f"      Datasets:        {pd.datasets.total}"
-                f" ({pd.datasets.supported} supported, {pd.datasets.unsupported} unsupported)"
+                f"      Datasets:        {pipeline_detail.datasets.total}"
+                f" ({pipeline_detail.datasets.supported} supported, {pipeline_detail.datasets.unsupported} unsupported)"
             )
             lines.append(
-                f"      Linked Services: {pd.linked_services.total}"
-                f" ({pd.linked_services.supported} supported, {pd.linked_services.unsupported} unsupported)"
+                f"      Linked Services: {pipeline_detail.linked_services.total}"
+                f" ({pipeline_detail.linked_services.supported} supported, {pipeline_detail.linked_services.unsupported} unsupported)"
             )
             lines.append(
-                f"      Triggers: {pd.total_triggers}, Integration Runtimes: {pd.total_integration_runtimes}"
+                f"      Triggers: {pipeline_detail.total_triggers}, Integration Runtimes: {pipeline_detail.total_integration_runtimes}"
             )
 
     return "\n".join(lines)
 
 
-# ---------------------------------------------------------------------------
-# ARM template loader
-# ---------------------------------------------------------------------------
-
-
-def _load_from_arm(
-    arm_template: dict[str, Any], *, factory_name_override: str | None = None
-) -> dict[str, Any]:
-    """Extracts ADF resources from an ARM template and normalises their shape.
-
-    The Azure Portal export uses ARM camelCase field names and nests pipeline
-    activities under ``properties.activities``.  The SDK ``as_dict()`` output
-    (and therefore the existing counter helpers) expects snake_case fields and
-    pipeline activities lifted to the top level.  This loader translates ARM
-    JSON into that internal shape so the rest of the profiler stays oblivious
-    to the input source.
+def _load_from_arm(arm_template: dict[str, Any], *, factory_name_override: str | None = None) -> dict[str, Any]:
+    """Extracts and normalizes ADF resources from an ARM template.
 
     Args:
-        arm_template: Parsed ARM template dict.  The ``resources`` array is
-            scanned; everything outside the Data Factory resource types is
-            ignored.
-        factory_name_override: Optional factory display name.  Used when the
-            ARM template does not include a top-level
-            ``Microsoft.DataFactory/factories`` resource.
+        arm_template: Parsed ARM template dict.
+        factory_name_override: Optional factory display name. Used when the
+            ARM template does not include a top-level 'Microsoft.DataFactory/factories' resource.
 
     Returns:
-        Dict with keys ``factory_name``, ``pipelines``, ``datasets``,
-        ``linked_services``, ``triggers``, and ``integration_runtimes``.
+        Dict with keys 'factory_name', 'pipelines', 'datasets', 'linked_services', 'triggers',
+        and 'integration_runtimes'.
     """
     resources = arm_template.get("resources") or []
     pipelines: list[dict] = []
@@ -242,8 +209,6 @@ def _load_from_arm(
             if factory_name is None:
                 factory_name = leaf_name
         elif resource_type == _ARM_PIPELINE_TYPE:
-            # Lift activities to top-level to match SDK shape; preserve
-            # the snake-cased ``properties`` for any downstream readers.
             pipelines.append(
                 {
                     "name": leaf_name,
@@ -275,18 +240,13 @@ def _load_from_arm(
 
 
 def _leaf_resource_name(arm_name: str) -> str:
-    """Strips the ``factory-name/`` prefix from an ARM resource name.
-
-    ARM names for nested resources look like ``factory-name/pipeline-name``.
-    This helper returns just the leaf segment so the resource name matches
-    what the SDK returns.
+    """Strips the 'factory_name/' prefix from an ARM resource name.
 
     Args:
-        arm_name: The raw ARM resource ``name`` field.
+        arm_name: ARM resource 'name' field.
 
     Returns:
-        The final ``/``-separated segment, or the input unchanged when there
-        is no slash.
+        Reformatted leaf resource name.
     """
     if "/" not in arm_name:
         return arm_name
@@ -297,10 +257,7 @@ _CAMEL_TO_SNAKE_RE = re.compile(r"(?<!^)(?=[A-Z])")
 
 
 def _arm_to_snake(value: Any) -> Any:
-    """Recursively converts camelCase dict keys to snake_case.
-
-    Walks dicts and lists; leaves leaf values (strings, numbers, bools,
-    ``None``) untouched.
+    """Converts camelCase property keys to snake_case.
 
     Args:
         value: Any JSON-decoded value from an ARM template.
@@ -322,14 +279,9 @@ def _camel_to_snake(name: str) -> str:
         name: Identifier to convert.
 
     Returns:
-        snake_cased identifier; pass-through for already-snake names.
+        snake_cased identifier.
     """
     return _CAMEL_TO_SNAKE_RE.sub("_", name).lower()
-
-
-# ---------------------------------------------------------------------------
-# Per-pipeline detail computation
-# ---------------------------------------------------------------------------
 
 
 def _build_pipeline_details(
@@ -340,153 +292,258 @@ def _build_pipeline_details(
     triggers: list[dict],
     integration_runtimes: list[dict],  # noqa: ARG001 -- accepted for caller symmetry
 ) -> list[PipelineDetail]:
-    """Computes the per-pipeline breakdown used by ``FactoryProfile``.
+    """Computes a per-pipeline breakdown of activities, datasets, linked services,
+    triggers, and integration runtimes.
 
-    For each pipeline, walks its activities (including nested ones inside
-    ``ForEach`` and ``IfCondition``) to collect activity types and any
-    ``reference_name`` strings that resolve to a known dataset or linked
-    service.  Linked-service references are augmented with the linked services
-    transitively reached via the pipeline's datasets so a dataset that points
-    at ``AzureSqlDatabase_LS`` counts toward the pipeline's linked-service
-    total even when the activity itself only names the dataset.
-
-    The integration-runtime count is derived from the ``connect_via``
-    reference on each linked service the pipeline reaches.
+    All input objects should be normalized to snake case.
 
     Args:
-        pipelines: Pipeline definitions in SDK (snake_case) shape.
-        datasets: Dataset definitions in SDK shape.
-        linked_services: Linked-service definitions in SDK shape.
-        triggers: Trigger definitions in SDK shape.
-        integration_runtimes: Integration-runtime definitions in SDK shape.
-            Accepted for API symmetry; the per-pipeline IR count is derived
-            from linked-service ``connect_via`` references.
+        pipelines: Pipeline definitions.
+        datasets: Dataset definitions.
+        linked_services: Linked-service definitions.
+        triggers: Trigger definitions.
+        integration_runtimes: Integration-runtime definitions.  Accepted for
+            caller symmetry; the per-pipeline IR count is derived from each
+            linked service's ``connect_via`` reference rather than this list.
 
     Returns:
-        One ``PipelineDetail`` per pipeline, in input order.
+        A list of ``PipelineDetail`` objects for each pipeline.
     """
-    dataset_by_name: dict[str, dict] = {ds.get("name", ""): ds for ds in datasets if isinstance(ds, dict)}
-    ls_by_name: dict[str, dict] = {ls.get("name", ""): ls for ls in linked_services if isinstance(ls, dict)}
+    del integration_runtimes  # see docstring — derived from linked-service connect_via
+    dataset_by_name = {ds.get("name", ""): ds for ds in datasets if isinstance(ds, dict)}
+    ls_by_name = {ls.get("name", ""): ls for ls in linked_services if isinstance(ls, dict)}
 
     details: list[PipelineDetail] = []
     for pipeline in pipelines:
         if not isinstance(pipeline, dict):
             logger.warning("Skipping non-dictionary pipeline in pipeline_details computation")
             continue
-        pipeline_name = pipeline.get("name", "Unknown")
-
-        # Walk every nested activity once
-        activities: list[dict] = []
-        _collect_activities(pipeline.get("activities") or [], activities)
-
-        # Activity supported/unsupported counts within this pipeline
-        activity_supported = sum(1 for a in activities if (a.get("type") or "Unknown") in SUPPORTED_ACTIVITY_TYPES)
-        activity_total = len(activities)
-        activity_counts = ObjectCount(
-            total=activity_total,
-            supported=activity_supported,
-            unsupported=activity_total - activity_supported,
-        )
-
-        # Datasets referenced by THIS pipeline's activities
-        referenced_dataset_names = _collect_referenced_dataset_names(activities, dataset_by_name)
-        ds_supported = 0
-        ds_unsupported = 0
-        for ds_name in referenced_dataset_names:
-            ds = dataset_by_name.get(ds_name)
-            if ds is None:
-                ds_unsupported += 1
-                continue
-            ds_type = (ds.get("properties") or {}).get("type") or "Unknown"
-            if ds_type in SUPPORTED_DATASET_TYPES:
-                ds_supported += 1
-            else:
-                ds_unsupported += 1
-        dataset_counts = ObjectCount(
-            total=len(referenced_dataset_names),
-            supported=ds_supported,
-            unsupported=ds_unsupported,
-        )
-
-        # Linked services: those referenced directly by activities + those
-        # reached transitively via referenced datasets
-        ls_names: set[str] = set()
-        ls_names.update(_collect_referenced_linked_service_names(activities, ls_by_name))
-        for ds_name in referenced_dataset_names:
-            ds = dataset_by_name.get(ds_name)
-            if ds is None:
-                continue
-            ls_ref = (ds.get("properties") or {}).get("linked_service_name") or {}
-            ls_ref_name = ls_ref.get("reference_name") if isinstance(ls_ref, dict) else None
-            if ls_ref_name:
-                ls_names.add(ls_ref_name)
-
-        ls_supported = 0
-        ls_unsupported = 0
-        for ls_name in sorted(ls_names):
-            ls = ls_by_name.get(ls_name)
-            if ls is None:
-                ls_unsupported += 1
-                continue
-            ls_type = (ls.get("properties") or {}).get("type") or "Unknown"
-            if ls_type in SUPPORTED_LINKED_SERVICE_TYPES:
-                ls_supported += 1
-            else:
-                ls_unsupported += 1
-        ls_counts = ObjectCount(
-            total=len(ls_names),
-            supported=ls_supported,
-            unsupported=ls_unsupported,
-        )
-
-        # Triggers binding this pipeline
-        trigger_count = _count_triggers_for_pipeline(pipeline_name, triggers)
-
-        # Distinct integration runtimes reached via this pipeline's linked services
-        ir_names: set[str] = set()
-        for ls_name in ls_names:
-            ls = ls_by_name.get(ls_name)
-            if ls is None:
-                continue
-            connect_via = (ls.get("properties") or {}).get("connect_via") or {}
-            ir_ref_name = connect_via.get("reference_name") if isinstance(connect_via, dict) else None
-            if ir_ref_name:
-                ir_names.add(ir_ref_name)
-
-        details.append(
-            PipelineDetail(
-                pipeline_name=pipeline_name,
-                activities=activity_counts,
-                datasets=dataset_counts,
-                linked_services=ls_counts,
-                total_activities=activity_counts.total,
-                total_datasets=dataset_counts.total,
-                total_linked_services=ls_counts.total,
-                total_triggers=trigger_count,
-                total_integration_runtimes=len(ir_names),
-            )
-        )
-
+        details.append(_build_pipeline_detail(pipeline, dataset_by_name, ls_by_name, triggers))
     return details
 
 
-def _collect_referenced_dataset_names(
-    activities: list[dict], dataset_by_name: dict[str, dict]
-) -> set[str]:
-    """Walks the activity tree collecting every dataset reference.
+def _build_pipeline_detail(
+    pipeline: dict,
+    dataset_by_name: dict[str, dict],
+    ls_by_name: dict[str, dict],
+    triggers: list[dict],
+) -> PipelineDetail:
+    """Builds a single ``PipelineDetail`` by delegating each sub-computation to a helper.
 
-    Dataset references appear as ``{"reference_name": ..., "type":
-    "DatasetReference"}`` blocks across ``inputs``, ``outputs``,
-    ``type_properties.dataset``, ``type_properties.source.dataset``,
-    ``type_properties.sink.dataset``, and a handful of other locations.
-    Instead of enumerating every spot, walk every nested dict in each activity
-    and pick out ``reference_name`` strings whose name matches a known
-    dataset.
+    Args:
+        pipeline: Pipeline definition in snake-case shape.
+        dataset_by_name: Name → dataset index for the factory.
+        ls_by_name: Name → linked-service index for the factory.
+        triggers: All triggers in the factory.
+
+    Returns:
+        A populated ``PipelineDetail``.
+    """
+    pipeline_name = pipeline.get("name", "Unknown")
+    activities = _collect_activities(pipeline.get("activities"))
+
+    activity_counts = _classify_pipeline_activities(activities)
+    referenced_dataset_names, dataset_counts = _classify_pipeline_datasets(activities, dataset_by_name)
+    linked_service_names, ls_counts = _classify_pipeline_linked_services(
+        activities=activities,
+        referenced_dataset_names=referenced_dataset_names,
+        dataset_by_name=dataset_by_name,
+        ls_by_name=ls_by_name,
+    )
+
+    return PipelineDetail(
+        pipeline_name=pipeline_name,
+        activities=activity_counts,
+        datasets=dataset_counts,
+        linked_services=ls_counts,
+        total_activities=activity_counts.total,
+        total_datasets=dataset_counts.total,
+        total_linked_services=ls_counts.total,
+        total_triggers=_count_triggers_for_pipeline(pipeline_name, triggers),
+        total_integration_runtimes=_count_integration_runtimes_for_pipeline(linked_service_names, ls_by_name),
+    )
+
+
+def _classify_pipeline_activities(activities: list[dict]) -> ObjectCount:
+    """Counts supported and unsupported activities within a single pipeline.
 
     Args:
         activities: Flat list of activity dicts (control-flow already expanded).
-        dataset_by_name: Index used to filter ``reference_name`` candidates so
-            we don't conflate linked-service or trigger references.
+
+    Returns:
+        ``ObjectCount`` with the total/supported/unsupported split.
+    """
+    supported = sum(1 for activity in activities if (activity.get("type") or "Unknown") in SUPPORTED_ACTIVITY_TYPES)
+    total = len(activities)
+    return ObjectCount(total=total, supported=supported, unsupported=total - supported)
+
+
+def _classify_pipeline_datasets(
+    activities: list[dict], dataset_by_name: dict[str, dict]
+) -> tuple[set[str], ObjectCount]:
+    """Collects every dataset name the activities reference, then classifies by supported type.
+
+    Args:
+        activities: Flat list of activity dicts.
+        dataset_by_name: Name → dataset index used to filter ``reference_name``
+            candidates and to look up dataset types.
+
+    Returns:
+        A tuple of ``(referenced_dataset_names, ObjectCount)``.  The set is
+        returned so the caller can feed it into the linked-service classifier
+        without re-walking the tree.
+    """
+    referenced = _collect_referenced_dataset_names(activities, dataset_by_name)
+    supported, unsupported = _count_supported_dataset_refs(referenced, dataset_by_name)
+    return referenced, ObjectCount(total=len(referenced), supported=supported, unsupported=unsupported)
+
+
+def _classify_pipeline_linked_services(
+    *,
+    activities: list[dict],
+    referenced_dataset_names: set[str],
+    dataset_by_name: dict[str, dict],
+    ls_by_name: dict[str, dict],
+) -> tuple[set[str], ObjectCount]:
+    """Resolves the linked services a pipeline reaches and classifies them.
+
+    A pipeline reaches a linked service in two ways: directly (an activity
+    such as ``WebActivity`` or ``SqlServerStoredProcedure`` carries a
+    ``LinkedServiceReference``) or transitively (an activity references a
+    dataset whose ``linked_service_name`` points at the LS).  Both paths are
+    unioned before classification.
+
+    Args:
+        activities: Flat list of activity dicts.
+        referenced_dataset_names: Datasets already known to be referenced by
+            this pipeline; their ``linked_service_name`` fields contribute the
+            transitive set of LS reachable via datasets.
+        dataset_by_name: Name → dataset index.
+        ls_by_name: Name → linked-service index.
+
+    Returns:
+        ``(linked_service_names, ObjectCount)``.  The set is returned so the
+        caller can pass it to :func:`_count_integration_runtimes_for_pipeline`.
+    """
+    linked_service_names = set(_collect_referenced_linked_service_names(activities, ls_by_name))
+    linked_service_names |= _collect_linked_service_names_from_datasets(referenced_dataset_names, dataset_by_name)
+    supported, unsupported = _count_supported_linked_service_refs(linked_service_names, ls_by_name)
+    return linked_service_names, ObjectCount(
+        total=len(linked_service_names), supported=supported, unsupported=unsupported
+    )
+
+
+def _collect_linked_service_names_from_datasets(
+    referenced_dataset_names: set[str], dataset_by_name: dict[str, dict]
+) -> set[str]:
+    """Returns LS names reached transitively via each dataset's ``linked_service_name``.
+
+    Args:
+        referenced_dataset_names: Datasets to inspect.
+        dataset_by_name: Name → dataset index.
+
+    Returns:
+        Unique LS names referenced by the given datasets.
+    """
+    found: set[str] = set()
+    for ds_name in referenced_dataset_names:
+        dataset = dataset_by_name.get(ds_name)
+        if dataset is None:
+            continue
+        ls_ref = (dataset.get("properties") or {}).get("linked_service_name") or {}
+        ref_name = ls_ref.get("reference_name") if isinstance(ls_ref, dict) else None
+        if ref_name:
+            found.add(ref_name)
+    return found
+
+
+def _count_supported_dataset_refs(
+    referenced_dataset_names: set[str], dataset_by_name: dict[str, dict]
+) -> tuple[int, int]:
+    """Tallies ``(supported, unsupported)`` references by looking up each dataset's type.
+
+    Args:
+        referenced_dataset_names: Dataset names to classify.
+        dataset_by_name: Name → dataset index.  Names not found are counted as
+            unsupported (the reference is broken or refers to a resource
+            outside this factory).
+
+    Returns:
+        ``(supported, unsupported)``.
+    """
+    supported = 0
+    unsupported = 0
+    for ds_name in referenced_dataset_names:
+        dataset = dataset_by_name.get(ds_name)
+        if dataset is None:
+            unsupported += 1
+            continue
+        ds_type = (dataset.get("properties") or {}).get("type") or "Unknown"
+        if ds_type in SUPPORTED_DATASET_TYPES:
+            supported += 1
+        else:
+            unsupported += 1
+    return supported, unsupported
+
+
+def _count_supported_linked_service_refs(
+    linked_service_names: set[str], ls_by_name: dict[str, dict]
+) -> tuple[int, int]:
+    """Tallies ``(supported, unsupported)`` references by looking up each LS's type.
+
+    Args:
+        linked_service_names: LS names to classify.
+        ls_by_name: Name → linked-service index.  Unknown names count as
+            unsupported.
+
+    Returns:
+        ``(supported, unsupported)``.
+    """
+    supported = 0
+    unsupported = 0
+    for ls_name in linked_service_names:
+        ls = ls_by_name.get(ls_name)
+        if ls is None:
+            unsupported += 1
+            continue
+        ls_type = (ls.get("properties") or {}).get("type") or "Unknown"
+        if ls_type in SUPPORTED_LINKED_SERVICE_TYPES:
+            supported += 1
+        else:
+            unsupported += 1
+    return supported, unsupported
+
+
+def _count_integration_runtimes_for_pipeline(
+    linked_service_names: set[str], ls_by_name: dict[str, dict]
+) -> int:
+    """Counts distinct integration runtimes reached via the given LS's ``connect_via``.
+
+    Args:
+        linked_service_names: LS names the pipeline reaches.
+        ls_by_name: Name → linked-service index.
+
+    Returns:
+        Count of unique IR names referenced.
+    """
+    ir_names: set[str] = set()
+    for ls_name in linked_service_names:
+        ls = ls_by_name.get(ls_name)
+        if ls is None:
+            continue
+        connect_via = (ls.get("properties") or {}).get("connect_via") or {}
+        ref_name = connect_via.get("reference_name") if isinstance(connect_via, dict) else None
+        if ref_name:
+            ir_names.add(ref_name)
+    return len(ir_names)
+
+
+def _collect_referenced_dataset_names(activities: list[dict], dataset_by_name: dict[str, dict]) -> set[str]:
+    """Walks the activity tree and collects dataset references.
+
+    Args:
+        activities: Flat list of activity dicts
+        dataset_by_name: Index used to filter dataset candidates
 
     Returns:
         Unique dataset names referenced anywhere in the activity tree.
@@ -503,17 +560,12 @@ def _collect_referenced_dataset_names(
     return found
 
 
-def _collect_referenced_linked_service_names(
-    activities: list[dict], ls_by_name: dict[str, dict]
-) -> set[str]:
-    """Walks the activity tree collecting every linked-service reference.
-
-    Some activities (e.g. ``SqlServerStoredProcedure``, ``WebActivity`` auth)
-    reference linked services directly without going through a dataset.
+def _collect_referenced_linked_service_names(activities: list[dict], ls_by_name: dict[str, dict]) -> set[str]:
+    """Walks the activity tree to collect linked-service references.
 
     Args:
         activities: Flat list of activity dicts.
-        ls_by_name: Index used to filter ``reference_name`` candidates.
+        ls_by_name: Index used to filter linked service reference candidates.
 
     Returns:
         Unique linked-service names referenced directly by activities.
@@ -528,10 +580,6 @@ def _collect_referenced_linked_service_names(
 
 def _iter_reference_pairs(value: Any):
     """Yields every ``(reference_name, type)`` pair found recursively in *value*.
-
-    ADF nests references as ``{"reference_name": "...", "type": "..."}`` (SDK
-    shape).  This helper walks dicts and lists yielding those pairs so the
-    caller can filter by reference type without enumerating every nesting site.
 
     Args:
         value: Any dict / list / scalar.
@@ -553,9 +601,6 @@ def _iter_reference_pairs(value: Any):
 
 def _count_triggers_for_pipeline(pipeline_name: str, triggers: list[dict]) -> int:
     """Counts triggers that bind to a given pipeline.
-
-    A trigger's ``properties.pipelines`` array carries ``pipeline_reference``
-    blocks; we match against the ``reference_name`` field.
 
     Args:
         pipeline_name: Logical pipeline name to match.
@@ -580,13 +625,8 @@ def _count_triggers_for_pipeline(pipeline_name: str, triggers: list[dict]) -> in
     return count
 
 
-# ---------------------------------------------------------------------------
-# Factory-wide counters (unchanged behaviour)
-# ---------------------------------------------------------------------------
-
-
 def _count_activities(pipelines: list) -> tuple[ObjectCount, list[str]]:
-    """Walk nested activities, classify supported/unsupported.
+    """Walks nested activities, classify supported/unsupported.
 
     Returns:
         A tuple of ``(ObjectCount, unsupported_type_names)``.
@@ -596,7 +636,7 @@ def _count_activities(pipelines: list) -> tuple[ObjectCount, list[str]]:
         if not isinstance(pipeline, dict):
             logger.warning("Skipping non-dictionary pipeline")
             continue
-        _collect_activities(pipeline.get("activities") or [], all_activities)
+        all_activities.extend(_collect_activities(pipeline.get("activities")))
 
     supported = 0
     unsupported_types: set[str] = set()
@@ -615,7 +655,7 @@ def _count_datasets(
     datasets: list[dict],
     linked_services: list[dict],
 ) -> tuple[ObjectCount, list[DatasetDetail], list[str]]:
-    """Classify datasets, build details.
+    """Classifies datasets and builds details.
 
     Returns:
         A tuple of ``(ObjectCount, dataset_details, unsupported_type_names)``.
@@ -687,24 +727,30 @@ def _build_integration_runtime_details(
     return ObjectCount(total, total, 0), details
 
 
-def _collect_activities(activities: list[dict] | None, result: list[dict]) -> None:
-    """Recursively collect all activities including nested ones.
+def _collect_activities(activities: list[dict] | None) -> list[dict]:
+    """Recursively collects every activity (including nested ones) into a new list.
+
+    Walks each activity's ``activities`` (ForEach inner) and
+    ``if_true_activities`` / ``if_false_activities`` (IfCondition branches),
+    appending the activity itself followed by its descendants in
+    pre-order.
 
     Args:
         activities: List of activity dicts to process, or ``None``.
-        result: Accumulator list where discovered activities are appended.
+
+    Returns:
+        A flat list of every activity dict found in *activities*.  An empty
+        list is returned when the input is ``None`` or empty.
     """
+    result: list[dict] = []
     for activity in activities or []:
         result.append(activity)
         # ForEach inner activities
-        inner = activity.get("activities") or []
-        if inner:
-            _collect_activities(inner, result)
+        result.extend(_collect_activities(activity.get("activities")))
         # IfCondition branches
         for branch_key in ("if_true_activities", "if_false_activities"):
-            branch = activity.get(branch_key) or []
-            if branch:
-                _collect_activities(branch, result)
+            result.extend(_collect_activities(activity.get(branch_key)))
+    return result
 
 
 def _build_linked_service_type_map(linked_services: list[dict]) -> dict[str, str | None]:

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
+from pathlib import Path
 from typing import Any
 
 import wkmigrate.translators.activity_translators.activity_translator as _activity_translator_registry  # noqa: F401
@@ -36,31 +38,51 @@ def profile_factory(
     client: FactoryClient | None = None,
     *,
     arm_template: dict[str, Any] | None = None,
+    git_export_root: str | Path | None = None,
     factory_name: str | None = None,
 ) -> FactoryProfile:
     """Profiles an Azure Data Factory resource.
 
-    Uses either an authenticated FactoryClient to profile using API calls against a deployed
-    Data Factory or an ARM template dict for offline profiling against exported ARM templates
-    (e.g. 'ARMTemplateForFactory.json').
+    Accepts one of three input sources (mutually exclusive — exactly one must be
+    provided):
+
+    * ``client``: live profiling against a deployed Data Factory via the
+      authenticated ``FactoryClient``.
+    * ``arm_template``: offline profiling against a parsed ARM template dict
+      (the shape ``ARMTemplateForFactory.json`` deserializes to, or the output
+      of an in-memory composition such as ``to_arm_template()``).
+    * ``git_export_root``: offline profiling against an ADF Git-mode export on
+      disk — the directory layout written by ADF Studio's Git integration,
+      with one JSON file per resource under per-kind subdirectories
+      (``pipeline/``, ``dataset/``, ``linkedService/``, ``trigger/``,
+      ``integrationRuntime/`` and optionally ``factory/``).
 
     Args:
         client: Authenticated FactoryClient for the target factory.
         arm_template: Parsed ARM JSON template.
-        factory_name: Override for the factory display name. Required when profiling an ARM
-            template that does not embed a ``Microsoft.DataFactory/factories`` resource.
-            Ignored when a client is supplied.
+        git_export_root: Filesystem path to the root of an ADF Git-mode export.
+        factory_name: Override for the factory display name. Used when
+            profiling an ARM template that does not embed a
+            ``Microsoft.DataFactory/factories`` resource, or a Git-mode export
+            that does not include a ``factory/`` subdirectory. Ignored when a
+            client is supplied.
 
     Returns:
         A ``FactoryProfile`` summarising the factory contents.
 
     Raises:
-        ValueError: If neither 'client' nor 'arm_template' was supplied, or if both were supplied.
+        ValueError: If zero or more than one of ``client``, ``arm_template``,
+            or ``git_export_root`` was supplied.
     """
-    if client is not None and arm_template is not None:
-        raise ValueError("'client' and 'arm_template' must not both be provided")
-    if client is None and arm_template is None:
-        raise ValueError("Either 'client' or 'arm_template' must be provided")
+    provided = [name for name, value in (
+        ("client", client),
+        ("arm_template", arm_template),
+        ("git_export_root", git_export_root),
+    ) if value is not None]
+    if len(provided) > 1:
+        raise ValueError(f"Only one of 'client', 'arm_template', or 'git_export_root' may be provided; got {provided}")
+    if not provided:
+        raise ValueError("One of 'client', 'arm_template', or 'git_export_root' must be provided")
 
     if client is not None:
         resolved_factory_name = client.factory_name
@@ -70,8 +92,11 @@ def profile_factory(
         triggers = client.list_triggers()
         integration_runtimes = client.list_integration_runtimes()
     else:
-        # arm_template is not None per the guards above; rebind for the typechecker.
-        loaded = _load_from_arm(arm_template, factory_name_override=factory_name)
+        if arm_template is not None:
+            loaded = _load_from_arm(arm_template, factory_name_override=factory_name)
+        else:
+            # git_export_root is not None per the guards above
+            loaded = _load_from_git_export(Path(git_export_root), factory_name_override=factory_name)
         resolved_factory_name = loaded["factory_name"]
         pipelines = loaded["pipelines"]
         datasets = loaded["datasets"]
@@ -213,7 +238,7 @@ def _load_from_arm(arm_template: dict[str, Any], *, factory_name_override: str |
         if resource_type == _ARM_FACTORY_TYPE:
             if factory_name is None:
                 factory_name = leaf_name
-        elif resource_type == _ARM_PIPELINE_TYPE:
+        if resource_type == _ARM_PIPELINE_TYPE:
             pipelines.append(
                 {
                     "name": leaf_name,
@@ -222,13 +247,13 @@ def _load_from_arm(arm_template: dict[str, Any], *, factory_name_override: str |
                     "properties": properties,
                 }
             )
-        elif resource_type == _ARM_DATASET_TYPE:
+        if resource_type == _ARM_DATASET_TYPE:
             datasets.append({"name": leaf_name, "properties": properties})
-        elif resource_type == _ARM_LINKED_SERVICE_TYPE:
+        if resource_type == _ARM_LINKED_SERVICE_TYPE:
             linked_services.append({"name": leaf_name, "properties": properties})
-        elif resource_type == _ARM_TRIGGER_TYPE:
+        if resource_type == _ARM_TRIGGER_TYPE:
             triggers.append({"name": leaf_name, "properties": properties})
-        elif resource_type == _ARM_INTEGRATION_RUNTIME_TYPE:
+        if resource_type == _ARM_INTEGRATION_RUNTIME_TYPE:
             integration_runtimes.append({"name": leaf_name, "properties": properties})
 
     if factory_name is None:
@@ -242,6 +267,85 @@ def _load_from_arm(arm_template: dict[str, Any], *, factory_name_override: str |
         "triggers": triggers,
         "integration_runtimes": integration_runtimes,
     }
+
+
+_GIT_EXPORT_KIND_TO_ARM_TYPE: dict[str, str] = {
+    "pipeline": _ARM_PIPELINE_TYPE,
+    "dataset": _ARM_DATASET_TYPE,
+    "linkedService": _ARM_LINKED_SERVICE_TYPE,
+    "trigger": _ARM_TRIGGER_TYPE,
+    "integrationRuntime": _ARM_INTEGRATION_RUNTIME_TYPE,
+}
+
+
+def _load_from_git_export(root: Path, *, factory_name_override: str | None = None) -> dict[str, Any]:
+    """Loads an ADF Git-mode export from disk and normalises it into ARM shape.
+
+    ADF Studio's Git integration writes each resource as its own JSON file
+    under a per-kind subdirectory of the configured root folder
+    (``pipeline/<name>.json``, ``dataset/<name>.json``,
+    ``linkedService/<name>.json``, ``trigger/<name>.json``,
+    ``integrationRuntime/<name>.json``, with optional ``factory/<name>.json``
+    metadata).  This loader walks those subdirectories, reads each file, wraps
+    the contents in the ARM-resource envelope, and then delegates to
+    :func:`_load_from_arm` so the snake_case key conversion and pipeline-shape
+    normalisation stay in a single place.
+
+    Args:
+        root: Filesystem path to the root of the Git-mode export.
+        factory_name_override: Optional factory display name.  Used when the
+            export does not include a ``factory/`` subdirectory.
+
+    Returns:
+        Dict with keys ``factory_name``, ``pipelines``, ``datasets``,
+        ``linked_services``, ``triggers``, and ``integration_runtimes`` -- the
+        same shape :func:`_load_from_arm` returns.
+
+    Raises:
+        ValueError: If ``root`` is not an existing directory.
+
+    Notes:
+        - Subdirectories that don't exist are skipped silently — a factory
+          with no triggers simply yields an empty ``triggers`` list.
+        - Files that fail to parse as JSON emit a warning and are skipped so
+          one bad file doesn't abort the whole profile.
+        - Files without a top-level ``name`` field fall back to the file stem.
+    """
+    if not root.is_dir():
+        raise ValueError(f"git_export_root {root!r} is not a directory")
+
+    factory_name: str | None = factory_name_override
+    factory_dir = root / "factory"
+    if factory_name is None and factory_dir.is_dir():
+        for factory_file in sorted(factory_dir.glob("*.json")):
+            try:
+                body = json.loads(factory_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("Skipping malformed Git-mode factory file %s: %s", factory_file, exc)
+                continue
+            factory_name = body.get("name") or factory_file.stem
+            break
+
+    resources: list[dict] = []
+    for kind, arm_type in _GIT_EXPORT_KIND_TO_ARM_TYPE.items():
+        kind_dir = root / kind
+        if not kind_dir.is_dir():
+            continue
+        for resource_file in sorted(kind_dir.glob("*.json")):
+            try:
+                body = json.loads(resource_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("Skipping malformed Git-mode file %s: %s", resource_file, exc)
+                continue
+            resources.append(
+                {
+                    "type": arm_type,
+                    "name": body.get("name") or resource_file.stem,
+                    "properties": body.get("properties", {}),
+                }
+            )
+
+    return _load_from_arm({"resources": resources}, factory_name_override=factory_name)
 
 
 def _leaf_resource_name(arm_name: str) -> str:
@@ -734,9 +838,7 @@ def _build_integration_runtime_details(
         properties = integration_runtime.get("properties", {})
         node_count = None
         if properties.get("type") == "SelfHosted":
-            node_count = (
-                properties.get("type_properties", {}).get("compute_properties", {}).get("number_of_nodes")
-            )
+            node_count = properties.get("type_properties", {}).get("compute_properties", {}).get("number_of_nodes")
         details.append(
             IntegrationRuntimeDetail(
                 name=integration_runtime.get("name", "Unknown"),

--- a/src/wkmigrate/profiler/profiler.py
+++ b/src/wkmigrate/profiler/profiler.py
@@ -36,31 +36,28 @@ _ARM_FACTORY_TYPE = "microsoft.datafactory/factories"
 
 def profile_factory(
     client: FactoryClient | None = None,
-    *,
-    arm_template: dict[str, Any] | None = None,
-    git_export_root: str | Path | None = None,
+    template: dict[str, Any] | None = None,
+    template_path: str | Path | None = None,
     factory_name: str | None = None,
 ) -> FactoryProfile:
     """Profiles an Azure Data Factory resource.
 
-    Accepts one of three input sources (mutually exclusive — exactly one must be
+    Accepts one of three input sources (mutually exclusive - exactly one must be
     provided):
 
     * ``client``: live profiling against a deployed Data Factory via the
       authenticated ``FactoryClient``.
-    * ``arm_template``: offline profiling against a parsed ARM template dict
-      (the shape ``ARMTemplateForFactory.json`` deserializes to, or the output
-      of an in-memory composition such as ``to_arm_template()``).
-    * ``git_export_root``: offline profiling against an ADF Git-mode export on
-      disk — the directory layout written by ADF Studio's Git integration,
+    * ``template``: offline profiling against Python dictionaries parsed from
+      ARM templates.
+    * ``template_path``: offline profiling against exported ARM templates
       with one JSON file per resource under per-kind subdirectories
       (``pipeline/``, ``dataset/``, ``linkedService/``, ``trigger/``,
       ``integrationRuntime/`` and optionally ``factory/``).
 
     Args:
         client: Authenticated FactoryClient for the target factory.
-        arm_template: Parsed ARM JSON template.
-        git_export_root: Filesystem path to the root of an ADF Git-mode export.
+        template: Parsed ARM JSON template.
+        template_path: Filesystem path to the root of an ADF Git-mode export.
         factory_name: Override for the factory display name. Used when
             profiling an ARM template that does not embed a
             ``Microsoft.DataFactory/factories`` resource, or a Git-mode export
@@ -74,15 +71,17 @@ def profile_factory(
         ValueError: If zero or more than one of ``client``, ``arm_template``,
             or ``git_export_root`` was supplied.
     """
-    provided = [name for name, value in (
-        ("client", client),
-        ("arm_template", arm_template),
-        ("git_export_root", git_export_root),
-    ) if value is not None]
+    provided = [
+        name
+        for name, value in (
+            ("client", client),
+            ("arm_template", template),
+            ("git_export_root", template_path),
+        )
+        if value is not None
+    ]
     if len(provided) > 1:
         raise ValueError(f"Only one of 'client', 'arm_template', or 'git_export_root' may be provided; got {provided}")
-    if not provided:
-        raise ValueError("One of 'client', 'arm_template', or 'git_export_root' must be provided")
 
     if client is not None:
         resolved_factory_name = client.factory_name
@@ -91,18 +90,24 @@ def profile_factory(
         linked_services = client.list_linked_services()
         triggers = client.list_triggers()
         integration_runtimes = client.list_integration_runtimes()
-    else:
-        if arm_template is not None:
-            loaded = _load_from_arm(arm_template, factory_name_override=factory_name)
-        else:
-            # git_export_root is not None per the guards above
-            loaded = _load_from_git_export(Path(git_export_root), factory_name_override=factory_name)
+    elif template is not None:
+        loaded = _load_from_arm(template, factory_name_override=factory_name)
         resolved_factory_name = loaded["factory_name"]
         pipelines = loaded["pipelines"]
         datasets = loaded["datasets"]
         linked_services = loaded["linked_services"]
         triggers = loaded["triggers"]
         integration_runtimes = loaded["integration_runtimes"]
+    elif template_path is not None:
+        loaded = _load_template(Path(template_path), factory_name_override=factory_name)
+        resolved_factory_name = loaded["factory_name"]
+        pipelines = loaded["pipelines"]
+        datasets = loaded["datasets"]
+        linked_services = loaded["linked_services"]
+        triggers = loaded["triggers"]
+        integration_runtimes = loaded["integration_runtimes"]
+    else:
+        raise ValueError("One of 'client', 'template', or 'template_path' must be provided")
 
     activity_counts, unsupported_activity_types = _count_activities(pipelines)
     dataset_counts, dataset_details, unsupported_dataset_types = _count_datasets(datasets, linked_services)
@@ -278,64 +283,55 @@ _GIT_EXPORT_KIND_TO_ARM_TYPE: dict[str, str] = {
 }
 
 
-def _load_from_git_export(root: Path, *, factory_name_override: str | None = None) -> dict[str, Any]:
-    """Loads an ADF Git-mode export from disk and normalises it into ARM shape.
+def _load_template(template_path: Path, *, factory_name_override: str | None = None) -> dict[str, Any]:
+    """Loads and normalizes exported ADF pipeline templates from a local path.
 
-    ADF Studio's Git integration writes each resource as its own JSON file
-    under a per-kind subdirectory of the configured root folder
-    (``pipeline/<name>.json``, ``dataset/<name>.json``,
-    ``linkedService/<name>.json``, ``trigger/<name>.json``,
-    ``integrationRuntime/<name>.json``, with optional ``factory/<name>.json``
-    metadata).  This loader walks those subdirectories, reads each file, wraps
-    the contents in the ARM-resource envelope, and then delegates to
-    :func:`_load_from_arm` so the snake_case key conversion and pipeline-shape
-    normalisation stay in a single place.
+    Uses the following folder structure:
+    * ``pipeline/<name>.json`` - for each pipeline
+    * ``dataset/<name>.json`` - for each dataset
+    * ``linkedService/<name>.json`` - for each linked service
+    * ``trigger/<name>.json`` - for each trigger
+    * ``integrationRuntime/<name>.json`` - for each integration runtime
+    * ``factory/<name>.json`` - for each data factory (optional)
 
     Args:
-        root: Filesystem path to the root of the Git-mode export.
+        template_path: Local path where the template JSON files are stored.
         factory_name_override: Optional factory display name.  Used when the
             export does not include a ``factory/`` subdirectory.
 
     Returns:
-        Dict with keys ``factory_name``, ``pipelines``, ``datasets``,
-        ``linked_services``, ``triggers``, and ``integration_runtimes`` -- the
+        Dictionary with keys ``factory_name``, ``pipelines``, ``datasets``,
+        ``linked_services``, ``triggers``, and ``integration_runtimes`` - the
         same shape :func:`_load_from_arm` returns.
 
     Raises:
-        ValueError: If ``root`` is not an existing directory.
-
-    Notes:
-        - Subdirectories that don't exist are skipped silently — a factory
-          with no triggers simply yields an empty ``triggers`` list.
-        - Files that fail to parse as JSON emit a warning and are skipped so
-          one bad file doesn't abort the whole profile.
-        - Files without a top-level ``name`` field fall back to the file stem.
+        ValueError: If ``template_path`` is not an existing directory.
     """
-    if not root.is_dir():
-        raise ValueError(f"git_export_root {root!r} is not a directory")
+    if not template_path.is_dir():
+        raise ValueError(f"git_export_root {template_path!r} is not a directory")
 
     factory_name: str | None = factory_name_override
-    factory_dir = root / "factory"
+    factory_dir = template_path / "factory"
     if factory_name is None and factory_dir.is_dir():
         for factory_file in sorted(factory_dir.glob("*.json")):
             try:
                 body = json.loads(factory_file.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError) as exc:
-                logger.warning("Skipping malformed Git-mode factory file %s: %s", factory_file, exc)
+                logger.warning(f"Skipping malformed Git-mode factory file '{factory_file}': {exc}")
                 continue
             factory_name = body.get("name") or factory_file.stem
             break
 
     resources: list[dict] = []
     for kind, arm_type in _GIT_EXPORT_KIND_TO_ARM_TYPE.items():
-        kind_dir = root / kind
+        kind_dir = template_path / kind
         if not kind_dir.is_dir():
             continue
         for resource_file in sorted(kind_dir.glob("*.json")):
             try:
                 body = json.loads(resource_file.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError) as exc:
-                logger.warning("Skipping malformed Git-mode file %s: %s", resource_file, exc)
+                logger.warning(f"Skipping malformed Git-mode file '{resource_file}': {exc}")
                 continue
             resources.append(
                 {

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -1,5 +1,7 @@
 """Unit tests for the profiler package."""
 
+from pathlib import Path
+
 import pytest
 
 from wkmigrate.profiler.profile import (
@@ -19,6 +21,7 @@ from wkmigrate.profiler.profiler import (
     _count_linked_services,
     _leaf_resource_name,
     _load_from_arm,
+    _load_from_git_export,
     format_profile,
     profile_factory,
 )
@@ -277,13 +280,17 @@ def test_profile_factory_requires_client_or_arm_template():
         profile_factory()
 
 
-def test_profile_factory_rejects_both_client_and_arm_template():
-    # Minimal sentinel; we won't reach the client path.
+def test_profile_factory_rejects_multiple_sources():
+    """At most one input source may be provided."""
+
     class _Sentinel:
         factory_name = "f"
 
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(ValueError, match="Only one of"):
         profile_factory(client=_Sentinel(), arm_template={"resources": []})  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Only one of"):
+        profile_factory(arm_template={"resources": []}, git_export_root="/tmp/whatever")
 
 
 # -- _camel_to_snake / _leaf_resource_name -------------------------------------
@@ -643,3 +650,130 @@ def test_format_profile_pipeline_details_section_rendered():
     assert "Datasets:        2 (2 supported, 0 unsupported)" in text
     assert "Linked Services: 2 (1 supported, 1 unsupported)" in text
     assert "Triggers: 1, Integration Runtimes: 1" in text
+
+
+# -- _load_from_git_export -----------------------------------------------------
+
+
+def _write_arm_resources_as_git_export(root: Path) -> None:
+    """Materialises ``_arm_template_sample()``'s resources as a Git-mode tree under *root*.
+
+    Mirrors how ADF Studio's Git integration writes one JSON file per
+    resource under per-kind subdirectories.  Used by the Git-mode loader
+    tests so they exercise the real filesystem-walk path.
+    """
+    import json as _json
+
+    arm_to_subdir: dict[str, str] = {
+        "Microsoft.DataFactory/factories": "factory",
+        "Microsoft.DataFactory/factories/pipelines": "pipeline",
+        "Microsoft.DataFactory/factories/datasets": "dataset",
+        "Microsoft.DataFactory/factories/linkedservices": "linkedService",
+        "Microsoft.DataFactory/factories/triggers": "trigger",
+        "Microsoft.DataFactory/factories/integrationRuntimes": "integrationRuntime",
+    }
+    for resource in _arm_template_sample()["resources"]:
+        resource_type = resource["type"]
+        # The ARM-template test sample uses mixed casing on
+        # ``integrationRuntimes`` but the subdir convention is camelCase
+        subdir = arm_to_subdir.get(resource_type)
+        if subdir is None:
+            continue
+        target = root / subdir
+        target.mkdir(parents=True, exist_ok=True)
+        leaf_name = resource["name"].split("/")[-1]
+        file_body = {"name": leaf_name, "properties": resource["properties"], "type": resource_type}
+        (target / f"{leaf_name}.json").write_text(_json.dumps(file_body, indent=2))
+
+
+def test_load_from_git_export_round_trips_arm_sample(tmp_path):
+    """Writing the ARM sample out as Git-mode files and loading back yields the same content."""
+    _write_arm_resources_as_git_export(tmp_path)
+    loaded = _load_from_git_export(tmp_path)
+    assert loaded["factory_name"] == "my-factory"
+    assert {p["name"] for p in loaded["pipelines"]} == {"orders-etl", "idle-pipeline"}
+    assert {d["name"] for d in loaded["datasets"]} == {"ds_blob_orders", "ds_sql_orders"}
+    assert {ls["name"] for ls in loaded["linked_services"]} == {
+        "AzureBlobFS_LS",
+        "AzureSql_LS",
+        "AzureDatabricks_LS",
+    }
+    # camelCase → snake_case normalisation still happens
+    orders = next(p for p in loaded["pipelines"] if p["name"] == "orders-etl")
+    assert orders["activities"][0]["inputs"][0]["reference_name"] == "ds_blob_orders"
+
+
+def test_load_from_git_export_uses_factory_subdir_for_name(tmp_path):
+    factory_dir = tmp_path / "factory"
+    factory_dir.mkdir()
+    (factory_dir / "my-factory.json").write_text('{"name": "my-factory", "properties": {}}')
+    (tmp_path / "pipeline").mkdir()
+    (tmp_path / "pipeline" / "p.json").write_text('{"name": "p", "properties": {"activities": []}}')
+    loaded = _load_from_git_export(tmp_path)
+    assert loaded["factory_name"] == "my-factory"
+
+
+def test_load_from_git_export_falls_back_to_override_when_no_factory_subdir(tmp_path):
+    (tmp_path / "pipeline").mkdir()
+    (tmp_path / "pipeline" / "p.json").write_text('{"name": "p", "properties": {"activities": []}}')
+    loaded = _load_from_git_export(tmp_path, factory_name_override="from-override")
+    assert loaded["factory_name"] == "from-override"
+
+
+def test_load_from_git_export_skips_missing_subdirectories(tmp_path):
+    """A factory with only pipelines should not blow up on missing dataset/trigger/etc dirs."""
+    (tmp_path / "pipeline").mkdir()
+    (tmp_path / "pipeline" / "only.json").write_text('{"name": "only", "properties": {"activities": []}}')
+    loaded = _load_from_git_export(tmp_path, factory_name_override="sparse")
+    assert [p["name"] for p in loaded["pipelines"]] == ["only"]
+    assert loaded["datasets"] == []
+    assert loaded["linked_services"] == []
+    assert loaded["triggers"] == []
+    assert loaded["integration_runtimes"] == []
+
+
+def test_load_from_git_export_skips_malformed_json(tmp_path, caplog):
+    (tmp_path / "pipeline").mkdir()
+    (tmp_path / "pipeline" / "good.json").write_text('{"name": "good", "properties": {"activities": []}}')
+    (tmp_path / "pipeline" / "broken.json").write_text("not valid json {{{")
+    with caplog.at_level("WARNING"):
+        loaded = _load_from_git_export(tmp_path, factory_name_override="f")
+    assert [p["name"] for p in loaded["pipelines"]] == ["good"]
+    assert any("malformed" in record.message.lower() for record in caplog.records)
+
+
+def test_load_from_git_export_falls_back_to_filename_stem_when_name_missing(tmp_path):
+    """A file lacking a top-level 'name' field uses its filename stem instead."""
+    (tmp_path / "pipeline").mkdir()
+    (tmp_path / "pipeline" / "pipeline_from_stem.json").write_text('{"properties": {"activities": []}}')
+    loaded = _load_from_git_export(tmp_path, factory_name_override="f")
+    assert [p["name"] for p in loaded["pipelines"]] == ["pipeline_from_stem"]
+
+
+def test_load_from_git_export_raises_when_root_missing(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(ValueError, match="not a directory"):
+        _load_from_git_export(missing)
+
+
+def test_profile_factory_via_git_export_end_to_end(tmp_path):
+    """End-to-end: Git-mode tree → profile_factory → FactoryProfile with pipeline_details."""
+    _write_arm_resources_as_git_export(tmp_path)
+    profile = profile_factory(git_export_root=tmp_path)
+    assert profile.factory_name == "my-factory"
+    assert profile.pipelines.total == 2
+    # Same factory-wide totals as the ARM-template path
+    assert profile.activities.total == 2
+    assert profile.datasets.total == 2
+    assert profile.linked_services.total == 3
+    # pipeline_details still computed
+    details_by_name = {pd.pipeline_name: pd for pd in profile.pipeline_details}
+    assert details_by_name["orders-etl"].activities.supported == 2
+    assert details_by_name["orders-etl"].total_integration_runtimes == 1
+
+
+def test_profile_factory_git_export_path_accepts_string(tmp_path):
+    """``git_export_root`` accepts both Path and string."""
+    _write_arm_resources_as_git_export(tmp_path)
+    profile = profile_factory(git_export_root=str(tmp_path))
+    assert profile.factory_name == "my-factory"

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -1,18 +1,26 @@
 """Unit tests for the profiler package."""
 
+import pytest
+
 from wkmigrate.profiler.profile import (
     DatasetDetail,
     FactoryProfile,
     IntegrationRuntimeDetail,
     ObjectCount,
+    PipelineDetail,
 )
 from wkmigrate.profiler.profiler import (
+    _build_integration_runtime_details,
+    _build_pipeline_details,
+    _camel_to_snake,
     _collect_activities,
     _count_activities,
     _count_datasets,
     _count_linked_services,
-    _build_integration_runtime_details,
+    _leaf_resource_name,
+    _load_from_arm,
     format_profile,
+    profile_factory,
 )
 
 
@@ -255,3 +263,385 @@ def test_format_profile_integration_runtime_details():
     )
     text = format_profile(profile)
     assert "ir-self (SelfHosted, 4 nodes)" in text
+
+
+# -- profile_factory argument validation ---------------------------------------
+
+
+def test_profile_factory_requires_client_or_arm_template():
+    with pytest.raises(ValueError, match="must be provided"):
+        profile_factory()
+
+
+def test_profile_factory_rejects_both_client_and_arm_template():
+    # Minimal sentinel; we won't reach the client path.
+    class _Sentinel:
+        factory_name = "f"
+
+    with pytest.raises(ValueError, match="not both"):
+        profile_factory(client=_Sentinel(), arm_template={"resources": []})  # type: ignore[arg-type]
+
+
+# -- _camel_to_snake / _leaf_resource_name -------------------------------------
+
+
+def test_camel_to_snake_basic():
+    assert _camel_to_snake("camelCase") == "camel_case"
+    assert _camel_to_snake("linkedServiceName") == "linked_service_name"
+    assert _camel_to_snake("snake_case") == "snake_case"
+    # ARM JSON field names are camelCase by convention (no all-caps acronyms),
+    # so the simple ``insert _ before every uppercase`` rule is sufficient.
+    # We don't test pathological cases like "URL" because they don't occur.
+
+
+def test_leaf_resource_name_strips_factory_prefix():
+    assert _leaf_resource_name("my-factory/my-pipeline") == "my-pipeline"
+    assert _leaf_resource_name("standalone-name") == "standalone-name"
+    assert _leaf_resource_name("") == ""
+
+
+# -- _load_from_arm ------------------------------------------------------------
+
+
+def _arm_template_sample() -> dict:
+    """Returns a small but representative ARM template for tests."""
+    return {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "resources": [
+            {
+                "type": "Microsoft.DataFactory/factories",
+                "name": "my-factory",
+                "properties": {},
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/pipelines",
+                "name": "my-factory/orders-etl",
+                "properties": {
+                    "activities": [
+                        {
+                            "type": "Copy",
+                            "name": "copyOrders",
+                            "inputs": [
+                                {"referenceName": "ds_blob_orders", "type": "DatasetReference"}
+                            ],
+                            "outputs": [
+                                {"referenceName": "ds_sql_orders", "type": "DatasetReference"}
+                            ],
+                        },
+                        {
+                            "type": "DatabricksNotebook",
+                            "name": "transformOrders",
+                            "linkedServiceName": {
+                                "referenceName": "AzureDatabricks_LS",
+                                "type": "LinkedServiceReference",
+                            },
+                        },
+                    ],
+                    "parameters": {"region": {"type": "String"}},
+                },
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/pipelines",
+                "name": "my-factory/idle-pipeline",
+                "properties": {"activities": []},
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/datasets",
+                "name": "my-factory/ds_blob_orders",
+                "properties": {
+                    "type": "Parquet",
+                    "linkedServiceName": {
+                        "referenceName": "AzureBlobFS_LS",
+                        "type": "LinkedServiceReference",
+                    },
+                },
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/datasets",
+                "name": "my-factory/ds_sql_orders",
+                "properties": {
+                    "type": "AzureSqlTable",
+                    "linkedServiceName": {
+                        "referenceName": "AzureSql_LS",
+                        "type": "LinkedServiceReference",
+                    },
+                },
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/linkedservices",
+                "name": "my-factory/AzureBlobFS_LS",
+                "properties": {"type": "AzureBlobFS"},
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/linkedservices",
+                "name": "my-factory/AzureSql_LS",
+                "properties": {
+                    "type": "AzureSqlDatabase",
+                    "connectVia": {
+                        "referenceName": "SelfHostedIR_OnPrem",
+                        "type": "IntegrationRuntimeReference",
+                    },
+                },
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/linkedservices",
+                "name": "my-factory/AzureDatabricks_LS",
+                "properties": {"type": "AzureDatabricks"},
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/triggers",
+                "name": "my-factory/daily-trigger",
+                "properties": {
+                    "type": "ScheduleTrigger",
+                    "pipelines": [
+                        {
+                            "pipelineReference": {
+                                "referenceName": "orders-etl",
+                                "type": "PipelineReference",
+                            }
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "Microsoft.DataFactory/factories/integrationRuntimes",
+                "name": "my-factory/SelfHostedIR_OnPrem",
+                "properties": {
+                    "type": "SelfHosted",
+                    "typeProperties": {"computeProperties": {"numberOfNodes": 2}},
+                },
+            },
+        ],
+    }
+
+
+def test_load_from_arm_factory_name_inferred_from_factory_resource():
+    loaded = _load_from_arm(_arm_template_sample())
+    assert loaded["factory_name"] == "my-factory"
+    assert {p["name"] for p in loaded["pipelines"]} == {"orders-etl", "idle-pipeline"}
+    assert {ds["name"] for ds in loaded["datasets"]} == {"ds_blob_orders", "ds_sql_orders"}
+
+
+def test_load_from_arm_normalises_camel_to_snake():
+    loaded = _load_from_arm(_arm_template_sample())
+    orders = next(p for p in loaded["pipelines"] if p["name"] == "orders-etl")
+    # Activities lifted to top-level and keys snake_cased
+    copy_act = orders["activities"][0]
+    assert copy_act["inputs"][0]["reference_name"] == "ds_blob_orders"
+    assert copy_act["outputs"][0]["reference_name"] == "ds_sql_orders"
+    nb = orders["activities"][1]
+    assert nb["linked_service_name"]["reference_name"] == "AzureDatabricks_LS"
+
+
+def test_load_from_arm_falls_back_to_override_when_no_factory_resource():
+    # An ARM template without a top-level factories resource should still load.
+    template = {
+        "resources": [
+            {
+                "type": "Microsoft.DataFactory/factories/pipelines",
+                "name": "ignored/orphan",
+                "properties": {"activities": []},
+            }
+        ]
+    }
+    loaded = _load_from_arm(template, factory_name_override="my-override")
+    assert loaded["factory_name"] == "my-override"
+
+
+def test_load_from_arm_factory_name_unknown_when_neither_source_present():
+    loaded = _load_from_arm({"resources": []})
+    assert loaded["factory_name"] == "Unknown"
+
+
+def test_profile_factory_via_arm_template_end_to_end():
+    """Full end-to-end profiling against a parsed ARM template."""
+    profile = profile_factory(arm_template=_arm_template_sample())
+    assert profile.factory_name == "my-factory"
+    assert profile.pipelines.total == 2
+    # 3 activities total: Copy + DatabricksNotebook + (none in idle pipeline)
+    assert profile.activities.total == 2
+    assert profile.activities.supported == 2
+    # 2 datasets (both supported types)
+    assert profile.datasets.total == 2
+    assert profile.datasets.supported == 2
+    # 3 linked services (all supported)
+    assert profile.linked_services.total == 3
+    assert profile.triggers.total == 1
+    assert profile.integration_runtimes.total == 1
+
+
+# -- _build_pipeline_details ---------------------------------------------------
+
+
+def test_pipeline_details_via_arm_template():
+    profile = profile_factory(arm_template=_arm_template_sample())
+    details_by_name = {pd.pipeline_name: pd for pd in profile.pipeline_details}
+    assert set(details_by_name) == {"orders-etl", "idle-pipeline"}
+
+    orders = details_by_name["orders-etl"]
+    # orders-etl has 2 activities (Copy + DatabricksNotebook), both supported
+    assert orders.activities == ObjectCount(total=2, supported=2, unsupported=0)
+    # References 2 datasets, both supported types
+    assert orders.datasets.total == 2
+    assert orders.datasets.supported == 2
+    # Linked services reached: AzureBlobFS_LS + AzureSql_LS (via datasets) +
+    # AzureDatabricks_LS (directly referenced by the notebook activity) = 3
+    assert orders.linked_services.total == 3
+    assert orders.linked_services.supported == 3
+    # 1 trigger binds this pipeline; 1 distinct IR is reached via AzureSql_LS.connect_via
+    assert orders.total_triggers == 1
+    assert orders.total_integration_runtimes == 1
+    # The mirror totals match the ObjectCount totals
+    assert orders.total_activities == orders.activities.total
+    assert orders.total_datasets == orders.datasets.total
+    assert orders.total_linked_services == orders.linked_services.total
+
+    idle = details_by_name["idle-pipeline"]
+    # Empty pipeline → zeros everywhere
+    assert idle.activities == ObjectCount(0, 0, 0)
+    assert idle.datasets == ObjectCount(0, 0, 0)
+    assert idle.linked_services == ObjectCount(0, 0, 0)
+    assert idle.total_triggers == 0
+    assert idle.total_integration_runtimes == 0
+
+
+def test_pipeline_details_supported_vs_unsupported_split():
+    """A pipeline mixing supported + unsupported activities and datasets surfaces both."""
+    pipelines = [
+        {
+            "name": "mixed",
+            "activities": [
+                {"type": "Copy", "name": "ok"},
+                {"type": "ExecutePipeline", "name": "bad", "type_properties": {}},
+                {
+                    "type": "Lookup",
+                    "name": "look",
+                    "type_properties": {
+                        "dataset": {"reference_name": "unsupported_ds", "type": "DatasetReference"}
+                    },
+                },
+            ],
+        }
+    ]
+    datasets = [
+        {
+            "name": "unsupported_ds",
+            "properties": {
+                "type": "SalesforceObject",
+                "linked_service_name": {"reference_name": "Salesforce_LS", "type": "LinkedServiceReference"},
+            },
+        }
+    ]
+    linked_services = [{"name": "Salesforce_LS", "properties": {"type": "Salesforce"}}]
+    details = _build_pipeline_details(
+        pipelines=pipelines,
+        datasets=datasets,
+        linked_services=linked_services,
+        triggers=[],
+        integration_runtimes=[],
+    )
+    assert len(details) == 1
+    pd = details[0]
+    assert pd.pipeline_name == "mixed"
+    # 3 activities: Copy (supported), ExecutePipeline (unsupported), Lookup (supported)
+    assert pd.activities == ObjectCount(total=3, supported=2, unsupported=1)
+    # 1 dataset referenced, type is unsupported
+    assert pd.datasets == ObjectCount(total=1, supported=0, unsupported=1)
+    # The dataset's LS is unsupported
+    assert pd.linked_services == ObjectCount(total=1, supported=0, unsupported=1)
+
+
+def test_pipeline_details_triggers_only_counted_when_bound_to_pipeline():
+    pipelines = [
+        {"name": "p1", "activities": []},
+        {"name": "p2", "activities": []},
+    ]
+    triggers = [
+        {
+            "name": "trig-p1",
+            "properties": {
+                "type": "ScheduleTrigger",
+                "pipelines": [{"pipeline_reference": {"reference_name": "p1", "type": "PipelineReference"}}],
+            },
+        }
+    ]
+    details = _build_pipeline_details(
+        pipelines=pipelines, datasets=[], linked_services=[], triggers=triggers, integration_runtimes=[]
+    )
+    by_name = {pd.pipeline_name: pd for pd in details}
+    assert by_name["p1"].total_triggers == 1
+    assert by_name["p2"].total_triggers == 0
+
+
+def test_pipeline_details_integration_runtime_via_linked_service_connect_via():
+    """IR count is derived from connect_via on the linked services a pipeline uses."""
+    pipelines = [
+        {
+            "name": "p",
+            "activities": [
+                {
+                    "type": "Copy",
+                    "name": "cp",
+                    "inputs": [{"reference_name": "ds", "type": "DatasetReference"}],
+                }
+            ],
+        }
+    ]
+    datasets = [
+        {
+            "name": "ds",
+            "properties": {
+                "type": "Parquet",
+                "linked_service_name": {"reference_name": "LS", "type": "LinkedServiceReference"},
+            },
+        }
+    ]
+    linked_services = [
+        {
+            "name": "LS",
+            "properties": {
+                "type": "AzureSqlDatabase",
+                "connect_via": {"reference_name": "OnPremIR", "type": "IntegrationRuntimeReference"},
+            },
+        }
+    ]
+    [pd] = _build_pipeline_details(
+        pipelines=pipelines,
+        datasets=datasets,
+        linked_services=linked_services,
+        triggers=[],
+        integration_runtimes=[{"name": "OnPremIR", "properties": {"type": "SelfHosted"}}],
+    )
+    assert pd.total_integration_runtimes == 1
+
+
+def test_format_profile_pipeline_details_section_rendered():
+    profile = FactoryProfile(
+        factory_name="f",
+        pipelines=ObjectCount(1, 1, 0),
+        activities=ObjectCount(0, 0, 0),
+        linked_services=ObjectCount(0, 0, 0),
+        datasets=ObjectCount(0, 0, 0),
+        triggers=ObjectCount(0, 0, 0),
+        integration_runtimes=ObjectCount(0, 0, 0),
+        pipeline_details=[
+            PipelineDetail(
+                pipeline_name="orders-etl",
+                activities=ObjectCount(3, 2, 1),
+                datasets=ObjectCount(2, 2, 0),
+                linked_services=ObjectCount(2, 1, 1),
+                total_activities=3,
+                total_datasets=2,
+                total_linked_services=2,
+                total_triggers=1,
+                total_integration_runtimes=1,
+            )
+        ],
+    )
+    text = format_profile(profile)
+    assert "Pipeline Details:" in text
+    assert "- orders-etl" in text
+    assert "Activities:      3 (2 supported, 1 unsupported)" in text
+    assert "Datasets:        2 (2 supported, 0 unsupported)" in text
+    assert "Linked Services: 2 (1 supported, 1 unsupported)" in text
+    assert "Triggers: 1, Integration Runtimes: 1" in text

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -29,8 +29,7 @@ from wkmigrate.profiler.profiler import (
 
 def test_collect_flat_activities():
     activities = [{"type": "Copy", "name": "A"}, {"type": "Lookup", "name": "B"}]
-    result: list[dict] = []
-    _collect_activities(activities, result)
+    result = _collect_activities(activities)
     assert len(result) == 2
 
 
@@ -45,8 +44,7 @@ def test_collect_nested_for_each():
             ],
         }
     ]
-    result: list[dict] = []
-    _collect_activities(activities, result)
+    result = _collect_activities(activities)
     assert len(result) == 3
 
 
@@ -62,19 +60,25 @@ def test_collect_nested_if_condition_branches():
             ],
         }
     ]
-    result: list[dict] = []
-    _collect_activities(activities, result)
+    result = _collect_activities(activities)
     # IfCondition itself + 1 true + 2 false = 4
     assert len(result) == 4
 
 
 def test_collect_empty_and_none():
-    result: list[dict] = []
-    _collect_activities([], result)
-    assert result == []
+    assert _collect_activities([]) == []
+    assert _collect_activities(None) == []
 
-    _collect_activities(None, result)
-    assert result == []
+
+def test_collect_activities_does_not_mutate_input():
+    """The pure-return contract: input activity list should not be modified."""
+    activities = [{"type": "Copy", "name": "A"}, {"type": "Lookup", "name": "B"}]
+    snapshot = [dict(a) for a in activities]
+    result = _collect_activities(activities)
+    assert activities == snapshot  # input untouched
+    # Result is a fresh list — appending to it must not mutate the caller's input
+    result.append({"type": "Wait", "name": "C"})
+    assert len(activities) == 2
 
 
 # -- _count_activities ---------------------------------------------------------
@@ -321,12 +325,8 @@ def _arm_template_sample() -> dict:
                         {
                             "type": "Copy",
                             "name": "copyOrders",
-                            "inputs": [
-                                {"referenceName": "ds_blob_orders", "type": "DatasetReference"}
-                            ],
-                            "outputs": [
-                                {"referenceName": "ds_sql_orders", "type": "DatasetReference"}
-                            ],
+                            "inputs": [{"referenceName": "ds_blob_orders", "type": "DatasetReference"}],
+                            "outputs": [{"referenceName": "ds_sql_orders", "type": "DatasetReference"}],
                         },
                         {
                             "type": "DatabricksNotebook",
@@ -516,9 +516,7 @@ def test_pipeline_details_supported_vs_unsupported_split():
                 {
                     "type": "Lookup",
                     "name": "look",
-                    "type_properties": {
-                        "dataset": {"reference_name": "unsupported_ds", "type": "DatasetReference"}
-                    },
+                    "type_properties": {"dataset": {"reference_name": "unsupported_ds", "type": "DatasetReference"}},
                 },
             ],
         }

--- a/tests/unit/test_profiler.py
+++ b/tests/unit/test_profiler.py
@@ -21,13 +21,10 @@ from wkmigrate.profiler.profiler import (
     _count_linked_services,
     _leaf_resource_name,
     _load_from_arm,
-    _load_from_git_export,
+    _load_template,
     format_profile,
     profile_factory,
 )
-
-
-# -- _collect_activities -------------------------------------------------------
 
 
 def test_collect_flat_activities():
@@ -84,9 +81,6 @@ def test_collect_activities_does_not_mutate_input():
     assert len(activities) == 2
 
 
-# -- _count_activities ---------------------------------------------------------
-
-
 def test_count_all_supported():
     pipelines = [{"activities": [{"type": "Copy"}, {"type": "Lookup"}]}]
     counts, unsupported = _count_activities(pipelines)
@@ -132,9 +126,6 @@ def test_count_activities_skips_non_dict_pipelines():
     assert counts.total == 1
 
 
-# -- _count_datasets -----------------------------------------------------------
-
-
 def test_count_datasets_supported():
     datasets = [
         {"name": "ds1", "properties": {"type": "Parquet", "linked_service_name": {"reference_name": "ls1"}}},
@@ -168,9 +159,6 @@ def test_count_datasets_missing_type():
     assert details[0].dataset_type == "Unknown"
 
 
-# -- _count_linked_services ----------------------------------------------------
-
-
 def test_count_linked_services_mixed():
     linked_services = [
         {"name": "ls1", "properties": {"type": "AzureBlobFS"}},
@@ -179,9 +167,6 @@ def test_count_linked_services_mixed():
     ]
     counts = _count_linked_services(linked_services)
     assert counts == ObjectCount(total=3, supported=2, unsupported=1)
-
-
-# -- _build_integration_runtime_details ----------------------------------------
 
 
 def test_integration_runtime_managed():
@@ -203,9 +188,6 @@ def test_integration_runtime_self_hosted_with_nodes():
     ]
     _, details = _build_integration_runtime_details(runtimes)
     assert details[0].node_count == 4
-
-
-# -- format_profile ------------------------------------------------------------
 
 
 def test_format_profile_basic():
@@ -272,9 +254,6 @@ def test_format_profile_integration_runtime_details():
     assert "ir-self (SelfHosted, 4 nodes)" in text
 
 
-# -- profile_factory argument validation ---------------------------------------
-
-
 def test_profile_factory_requires_client_or_arm_template():
     with pytest.raises(ValueError, match="must be provided"):
         profile_factory()
@@ -287,13 +266,10 @@ def test_profile_factory_rejects_multiple_sources():
         factory_name = "f"
 
     with pytest.raises(ValueError, match="Only one of"):
-        profile_factory(client=_Sentinel(), arm_template={"resources": []})  # type: ignore[arg-type]
+        profile_factory(client=_Sentinel(), template={"resources": []})  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="Only one of"):
-        profile_factory(arm_template={"resources": []}, git_export_root="/tmp/whatever")
-
-
-# -- _camel_to_snake / _leaf_resource_name -------------------------------------
+        profile_factory(template={"resources": []}, template_path="/tmp/whatever")
 
 
 def test_camel_to_snake_basic():
@@ -309,9 +285,6 @@ def test_leaf_resource_name_strips_factory_prefix():
     assert _leaf_resource_name("my-factory/my-pipeline") == "my-pipeline"
     assert _leaf_resource_name("standalone-name") == "standalone-name"
     assert _leaf_resource_name("") == ""
-
-
-# -- _load_from_arm ------------------------------------------------------------
 
 
 def _arm_template_sample() -> dict:
@@ -462,7 +435,7 @@ def test_load_from_arm_factory_name_unknown_when_neither_source_present():
 
 def test_profile_factory_via_arm_template_end_to_end():
     """Full end-to-end profiling against a parsed ARM template."""
-    profile = profile_factory(arm_template=_arm_template_sample())
+    profile = profile_factory(template=_arm_template_sample())
     assert profile.factory_name == "my-factory"
     assert profile.pipelines.total == 2
     # 3 activities total: Copy + DatabricksNotebook + (none in idle pipeline)
@@ -477,11 +450,8 @@ def test_profile_factory_via_arm_template_end_to_end():
     assert profile.integration_runtimes.total == 1
 
 
-# -- _build_pipeline_details ---------------------------------------------------
-
-
 def test_pipeline_details_via_arm_template():
-    profile = profile_factory(arm_template=_arm_template_sample())
+    profile = profile_factory(template=_arm_template_sample())
     details_by_name = {pd.pipeline_name: pd for pd in profile.pipeline_details}
     assert set(details_by_name) == {"orders-etl", "idle-pipeline"}
 
@@ -652,9 +622,6 @@ def test_format_profile_pipeline_details_section_rendered():
     assert "Triggers: 1, Integration Runtimes: 1" in text
 
 
-# -- _load_from_git_export -----------------------------------------------------
-
-
 def _write_arm_resources_as_git_export(root: Path) -> None:
     """Materialises ``_arm_template_sample()``'s resources as a Git-mode tree under *root*.
 
@@ -686,10 +653,10 @@ def _write_arm_resources_as_git_export(root: Path) -> None:
         (target / f"{leaf_name}.json").write_text(_json.dumps(file_body, indent=2))
 
 
-def test_load_from_git_export_round_trips_arm_sample(tmp_path):
+def test_load_template_round_trips_arm_sample(tmp_path):
     """Writing the ARM sample out as Git-mode files and loading back yields the same content."""
     _write_arm_resources_as_git_export(tmp_path)
-    loaded = _load_from_git_export(tmp_path)
+    loaded = _load_template(tmp_path)
     assert loaded["factory_name"] == "my-factory"
     assert {p["name"] for p in loaded["pipelines"]} == {"orders-etl", "idle-pipeline"}
     assert {d["name"] for d in loaded["datasets"]} == {"ds_blob_orders", "ds_sql_orders"}
@@ -703,28 +670,28 @@ def test_load_from_git_export_round_trips_arm_sample(tmp_path):
     assert orders["activities"][0]["inputs"][0]["reference_name"] == "ds_blob_orders"
 
 
-def test_load_from_git_export_uses_factory_subdir_for_name(tmp_path):
+def test_load_template_uses_factory_subdir_for_name(tmp_path):
     factory_dir = tmp_path / "factory"
     factory_dir.mkdir()
     (factory_dir / "my-factory.json").write_text('{"name": "my-factory", "properties": {}}')
     (tmp_path / "pipeline").mkdir()
     (tmp_path / "pipeline" / "p.json").write_text('{"name": "p", "properties": {"activities": []}}')
-    loaded = _load_from_git_export(tmp_path)
+    loaded = _load_template(tmp_path)
     assert loaded["factory_name"] == "my-factory"
 
 
-def test_load_from_git_export_falls_back_to_override_when_no_factory_subdir(tmp_path):
+def test_load_template_falls_back_to_override_when_no_factory_subdir(tmp_path):
     (tmp_path / "pipeline").mkdir()
     (tmp_path / "pipeline" / "p.json").write_text('{"name": "p", "properties": {"activities": []}}')
-    loaded = _load_from_git_export(tmp_path, factory_name_override="from-override")
+    loaded = _load_template(tmp_path, factory_name_override="from-override")
     assert loaded["factory_name"] == "from-override"
 
 
-def test_load_from_git_export_skips_missing_subdirectories(tmp_path):
+def test_load_template_skips_missing_subdirectories(tmp_path):
     """A factory with only pipelines should not blow up on missing dataset/trigger/etc dirs."""
     (tmp_path / "pipeline").mkdir()
     (tmp_path / "pipeline" / "only.json").write_text('{"name": "only", "properties": {"activities": []}}')
-    loaded = _load_from_git_export(tmp_path, factory_name_override="sparse")
+    loaded = _load_template(tmp_path, factory_name_override="sparse")
     assert [p["name"] for p in loaded["pipelines"]] == ["only"]
     assert loaded["datasets"] == []
     assert loaded["linked_services"] == []
@@ -732,34 +699,34 @@ def test_load_from_git_export_skips_missing_subdirectories(tmp_path):
     assert loaded["integration_runtimes"] == []
 
 
-def test_load_from_git_export_skips_malformed_json(tmp_path, caplog):
+def test_load_template_skips_malformed_json(tmp_path, caplog):
     (tmp_path / "pipeline").mkdir()
     (tmp_path / "pipeline" / "good.json").write_text('{"name": "good", "properties": {"activities": []}}')
     (tmp_path / "pipeline" / "broken.json").write_text("not valid json {{{")
     with caplog.at_level("WARNING"):
-        loaded = _load_from_git_export(tmp_path, factory_name_override="f")
+        loaded = _load_template(tmp_path, factory_name_override="f")
     assert [p["name"] for p in loaded["pipelines"]] == ["good"]
     assert any("malformed" in record.message.lower() for record in caplog.records)
 
 
-def test_load_from_git_export_falls_back_to_filename_stem_when_name_missing(tmp_path):
+def test_load_template_falls_back_to_filename_stem_when_name_missing(tmp_path):
     """A file lacking a top-level 'name' field uses its filename stem instead."""
     (tmp_path / "pipeline").mkdir()
     (tmp_path / "pipeline" / "pipeline_from_stem.json").write_text('{"properties": {"activities": []}}')
-    loaded = _load_from_git_export(tmp_path, factory_name_override="f")
+    loaded = _load_template(tmp_path, factory_name_override="f")
     assert [p["name"] for p in loaded["pipelines"]] == ["pipeline_from_stem"]
 
 
-def test_load_from_git_export_raises_when_root_missing(tmp_path):
+def test_load_template_raises_when_root_missing(tmp_path):
     missing = tmp_path / "does-not-exist"
     with pytest.raises(ValueError, match="not a directory"):
-        _load_from_git_export(missing)
+        _load_template(missing)
 
 
 def test_profile_factory_via_git_export_end_to_end(tmp_path):
     """End-to-end: Git-mode tree → profile_factory → FactoryProfile with pipeline_details."""
     _write_arm_resources_as_git_export(tmp_path)
-    profile = profile_factory(git_export_root=tmp_path)
+    profile = profile_factory(template_path=tmp_path)
     assert profile.factory_name == "my-factory"
     assert profile.pipelines.total == 2
     # Same factory-wide totals as the ARM-template path
@@ -775,5 +742,5 @@ def test_profile_factory_via_git_export_end_to_end(tmp_path):
 def test_profile_factory_git_export_path_accepts_string(tmp_path):
     """``git_export_root`` accepts both Path and string."""
     _write_arm_resources_as_git_export(tmp_path)
-    profile = profile_factory(git_export_root=str(tmp_path))
+    profile = profile_factory(template_path=str(tmp_path))
     assert profile.factory_name == "my-factory"


### PR DESCRIPTION
## Changes

Makes the `FactoryClient` argument optional on `profile_factory` and adds a parallel `arm_template=` path that profiles a parsed ADF ARM export, plus a new `pipeline_details` field on `FactoryProfile` that gives a per-pipeline breakdown of supported/unsupported activities, datasets, and linked services alongside each pipeline's trigger and integration-runtime totals so users can quickly see which pipelines are most translatable by wkmigrate.

### Linked issues

N/A

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests